### PR TITLE
Add reannounce for bugged trackers

### DIFF
--- a/.qbt.toml.example
+++ b/.qbt.toml.example
@@ -3,3 +3,9 @@ host     = "127.0.0.1" # qbittorrent webui-api hostname/ip
 port     = 6776        # qbittorrent webui-api port
 login    = "user"      # qbittorrent webui-api user
 password = "password"  # qbittorrent webui-api password
+
+# some trackers are bugged and need to reannounce before torrent can start
+[reannounce]
+enabled = true  # true or false
+attempts = 10   # attempts to run. Run max 10-30 times
+interval = 3000 # interval between attempts in milliseconds

--- a/.qbt.toml.example
+++ b/.qbt.toml.example
@@ -8,4 +8,4 @@ password = "password"  # qbittorrent webui-api password
 [reannounce]
 enabled = true  # true or false
 attempts = 10   # attempts to run. Run max 10-30 times
-interval = 3000 # interval between attempts in milliseconds
+interval = 7000 # interval between attempts in milliseconds

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"log"
+	"time"
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
 	"github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
@@ -83,6 +84,14 @@ func RunAdd() *cobra.Command {
 				log.Fatalf("adding torrent failed: %v", err)
 			}
 
+			// some trackers are bugged or slow so we need to re-announce the torrent until it works
+			if config.Reannounce.Enabled && !paused {
+				err = checkTrackerStatus(*qb, res)
+				if err != nil {
+					log.Fatalf("could not get tracker status for torrent: %v", err)
+				}
+			}
+
 			log.Printf("torrent successfully added: %v", res)
 		} else {
 			log.Println("dry-run: torrent successfully added!")
@@ -90,4 +99,59 @@ func RunAdd() *cobra.Command {
 	}
 
 	return command
+}
+
+func checkTrackerStatus(qb qbittorrent.Client, hash string) error {
+	announceOK := false
+	attempts := 0
+
+	for attempts < config.Reannounce.Attempts {
+		trackers, err := qb.GetTorrentTrackers(hash)
+		if err != nil {
+			log.Fatalf("could not get trackers of torrent: %v %v", hash, err)
+		}
+
+		// check if status not working or something else
+		_, working := findTrackerStatus(trackers, 2)
+
+		if !working {
+			err = qb.ReAnnounceTorrents([]string{hash})
+			if err != nil {
+				return err
+			}
+
+			time.Sleep(3000 * time.Millisecond)
+			attempts++
+			continue
+		} else {
+			announceOK = true
+			break
+		}
+	}
+
+	if !announceOK {
+		log.Println("Announce not ok, deleting torrent")
+		err := qb.DeleteTorrents([]string{hash}, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Check if status not working or something else
+// https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
+//  0 Tracker is disabled (used for DHT, PeX, and LSD)
+//  1 Tracker has not been contacted yet
+//  2 Tracker has been contacted and is working
+//  3 Tracker is updating
+//  4 Tracker has been contacted, but it is not working (or doesn't send proper replies)
+func findTrackerStatus(slice []qbittorrent.TorrentTracker, val int) (int, bool) {
+	for i, item := range slice {
+		if item.Status == val {
+			return i, true
+		}
+	}
+	return -1, false
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -120,7 +120,7 @@ func checkTrackerStatus(qb qbittorrent.Client, hash string) error {
 				return err
 			}
 
-			time.Sleep(3000 * time.Millisecond)
+			time.Sleep(time.Duration(config.Reannounce.Interval) * time.Millisecond)
 			attempts++
 			continue
 		} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,9 +11,10 @@ import (
 )
 
 var (
-	CfgFile string
-	Config  domain.AppConfig
-	Qbit    domain.QbitConfig
+	CfgFile    string
+	Config     domain.AppConfig
+	Qbit       domain.QbitConfig
+	Reannounce domain.ReannounceSettings
 )
 
 // InitConfig initialize config
@@ -46,4 +47,5 @@ func InitConfig() {
 		os.Exit(1)
 	}
 	Qbit = Config.Qbit
+	Reannounce = Config.Reannounce
 }

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -7,7 +7,14 @@ type QbitConfig struct {
 	Password string `mapstructure:"password"`
 }
 
+type ReannounceSettings struct {
+	Enabled  bool `mapstructure:"enabled"`
+	Attempts int  `mapstructure:"attempts"`
+	Interval int  `mapstructure:"interval"`
+}
+
 type AppConfig struct {
-	Debug bool       `mapstructure:"debug"`
-	Qbit  QbitConfig `mapstructure:"qbittorrent"`
+	Debug      bool               `mapstructure:"debug"`
+	Qbit       QbitConfig         `mapstructure:"qbittorrent"`
+	Reannounce ReannounceSettings `mapstructure:"reannounce"`
 }

--- a/pkg/qbittorrent/client.go
+++ b/pkg/qbittorrent/client.go
@@ -2,11 +2,8 @@ package qbittorrent
 
 import (
 	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -15,8 +12,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"github.com/anacrolix/torrent/metainfo"
 
 	"golang.org/x/net/publicsuffix"
 )
@@ -81,7 +76,7 @@ func (c *Client) post(endpoint string, opts map[string]string) (*http.Response, 
 		log.Fatal(err)
 	}
 
-	//// add the content-type so qbittorrent knows what to expect
+	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.http.Do(req)
@@ -153,107 +148,4 @@ func (c *Client) postFile(endpoint string, fileName string, opts map[string]stri
 	}
 
 	return res, nil
-}
-
-func (c *Client) Login() error {
-	credentials := make(map[string]string)
-	credentials["username"] = c.settings.Username
-	credentials["password"] = c.settings.Password
-
-	resp, err := c.post("auth/login", credentials)
-	if err != nil {
-		log.Fatalf("login error: %v", err)
-	} else if resp.StatusCode != http.StatusOK { // check for correct status code
-		log.Fatalf("login error bad status %v", err)
-	}
-
-	// place cookies in jar for future requests
-	if cookies := resp.Cookies(); len(cookies) > 0 {
-		cookieURL, _ := url.Parse("http://localhost:8080")
-		c.http.Jar.SetCookies(cookieURL, cookies)
-	}
-
-	return nil
-}
-
-func (c *Client) GetTorrents() ([]Torrent, error) {
-	var torrents []Torrent
-
-	resp, err := c.get("torrents/info", nil)
-	if err != nil {
-		log.Fatalf("error fetching torrents: %v", err)
-	}
-
-	defer resp.Body.Close()
-
-	body, readErr := ioutil.ReadAll(resp.Body)
-	if readErr != nil {
-		log.Fatal(readErr)
-	}
-
-	err = json.Unmarshal(body, &torrents)
-	if err != nil {
-		log.Fatalf("could not unmarshal json: %v", err)
-	}
-
-	return torrents, nil
-}
-
-func (c *Client) GetTorrentsRaw() (string, error) {
-	resp, err := c.get("torrents/info", nil)
-	if err != nil {
-		log.Fatalf("error fetching torrents: %v", err)
-	}
-
-	defer resp.Body.Close()
-
-	data, _ := ioutil.ReadAll(resp.Body)
-
-	return string(data), nil
-}
-
-// AddTorrentFromFile add new torrent from torrent file
-func (c *Client) AddTorrentFromFile(file string, options map[string]string) (hash string, err error) {
-	// Get meta info from file to find out the hash for later use
-	t, err := metainfo.LoadFromFile(file)
-	if err != nil {
-		log.Fatalf("could not open file %v", err)
-	}
-
-	// Get hash from info
-	torrentHash := metainfo.HashBytes(t.InfoBytes)
-	hash = torrentHash.String()
-	if hash == "" {
-		return "", errors.New("could not stringify torrent hash")
-	}
-
-	res, err := c.postFile("torrents/add", file, options)
-	if err != nil {
-		return "", err
-	} else if res.StatusCode != http.StatusOK {
-		return "", err
-	}
-
-	defer res.Body.Close()
-
-	return hash, nil
-}
-
-func (c *Client) AddTorrentFromMagnet(u string, options map[string]string) (hash string, err error) {
-	m, err := metainfo.ParseMagnetURI(u)
-	if err != nil {
-		log.Fatalf("could not parse magnet URI %v", err)
-	}
-
-	options["urls"] = u
-	res, err := c.post("torrents/add", options)
-	if err != nil {
-		return "", err
-	} else if res.StatusCode != http.StatusOK {
-		return "", err
-	}
-
-	defer res.Body.Close()
-
-	return m.InfoHash.HexString(), nil
 }

--- a/pkg/qbittorrent/domain.go
+++ b/pkg/qbittorrent/domain.go
@@ -45,6 +45,21 @@ type Torrent struct {
 	UpSpeed            int          `json:"upspeed"`
 }
 
+type TorrentTrackersResponse struct {
+	Trackers []TorrentTracker `json:"trackers"`
+}
+
+type TorrentTracker struct {
+	Url           string `json:"url"`
+	Status        int    `json:"status"`
+	Tier          uint   `json:"tier"`
+	NumPeers      int    `json:"num_peers"`
+	NumSeeds      int    `json:"num_seeds"`
+	NumLeechers   int    `json:"num_leechers"`
+	NumDownloaded int    `json:"num_downloaded"`
+	Message       string `json:"msg"`
+}
+
 type TorrentState string
 
 const (
@@ -97,7 +112,7 @@ const (
 	TorrentStateForceDl TorrentState = "forceDL"
 
 	// Checking resume data on qBt startup
-	TorrentstateCheckingResumeData TorrentState = "checkingResumeData"
+	TorrentStateCheckingResumeData TorrentState = "checkingResumeData"
 
 	// Torrent is moving to another location
 	TorrentStateMoving TorrentState = "moving"

--- a/pkg/qbittorrent/domain.go
+++ b/pkg/qbittorrent/domain.go
@@ -50,9 +50,9 @@ type TorrentTrackersResponse struct {
 }
 
 type TorrentTracker struct {
+	//Tier          uint   `json:"tier"` // can be both empty "" and int
 	Url           string `json:"url"`
 	Status        int    `json:"status"`
-	Tier          uint   `json:"tier"`
 	NumPeers      int    `json:"num_peers"`
 	NumSeeds      int    `json:"num_seeds"`
 	NumLeechers   int    `json:"num_leechers"`

--- a/pkg/qbittorrent/methods.go
+++ b/pkg/qbittorrent/methods.go
@@ -1,0 +1,188 @@
+package qbittorrent
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+func (c *Client) Login() error {
+	credentials := make(map[string]string)
+	credentials["username"] = c.settings.Username
+	credentials["password"] = c.settings.Password
+
+	resp, err := c.post("auth/login", credentials)
+	if err != nil {
+		log.Fatalf("login error: %v", err)
+	} else if resp.StatusCode != http.StatusOK { // check for correct status code
+		log.Fatalf("login error bad status %v", err)
+	}
+
+	// place cookies in jar for future requests
+	if cookies := resp.Cookies(); len(cookies) > 0 {
+		cookieURL, _ := url.Parse("http://localhost:8080")
+		c.http.Jar.SetCookies(cookieURL, cookies)
+	}
+
+	return nil
+}
+
+func (c *Client) GetTorrents() ([]Torrent, error) {
+	var torrents []Torrent
+
+	resp, err := c.get("torrents/info", nil)
+	if err != nil {
+		log.Fatalf("error fetching torrents: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	err = json.Unmarshal(body, &torrents)
+	if err != nil {
+		log.Fatalf("could not unmarshal json: %v", err)
+	}
+
+	return torrents, nil
+}
+
+func (c *Client) GetTorrentsRaw() (string, error) {
+	resp, err := c.get("torrents/info", nil)
+	if err != nil {
+		log.Fatalf("error fetching torrents: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	data, _ := ioutil.ReadAll(resp.Body)
+
+	return string(data), nil
+}
+
+func (c *Client) GetTorrentTrackers(hash string) ([]TorrentTracker, error) {
+	var trackers []TorrentTracker
+
+	params := url.Values{}
+	params.Add("hash", hash)
+
+	p := params.Encode()
+
+	resp, err := c.get("torrents/trackers?"+p, nil)
+	if err != nil {
+		log.Fatalf("error fetching torrents: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	err = json.Unmarshal(body, &trackers)
+	if err != nil {
+		log.Fatalf("could not unmarshal json: %v", err)
+	}
+
+	return trackers, nil
+}
+
+// AddTorrentFromFile add new torrent from torrent file
+func (c *Client) AddTorrentFromFile(file string, options map[string]string) (hash string, err error) {
+	// Get meta info from file to find out the hash for later use
+	t, err := metainfo.LoadFromFile(file)
+	if err != nil {
+		log.Fatalf("could not open file %v", err)
+	}
+
+	// Get hash from info
+	torrentHash := metainfo.HashBytes(t.InfoBytes)
+	hash = torrentHash.String()
+	if hash == "" {
+		return "", errors.New("could not stringify torrent hash")
+	}
+
+	res, err := c.postFile("torrents/add", file, options)
+	if err != nil {
+		return "", err
+	} else if res.StatusCode != http.StatusOK {
+		return "", err
+	}
+
+	defer res.Body.Close()
+
+	return hash, nil
+}
+
+func (c *Client) AddTorrentFromMagnet(u string, options map[string]string) (hash string, err error) {
+	m, err := metainfo.ParseMagnetURI(u)
+	if err != nil {
+		log.Fatalf("could not parse magnet URI %v", err)
+	}
+
+	options["urls"] = u
+	res, err := c.post("torrents/add", options)
+	if err != nil {
+		return "", err
+	} else if res.StatusCode != http.StatusOK {
+		return "", err
+	}
+
+	defer res.Body.Close()
+
+	return m.InfoHash.HexString(), nil
+}
+
+func (c *Client) DeleteTorrents(hashes []string, deleteFiles bool) error {
+	v := url.Values{}
+
+	// Add hashes together with | separator
+	hv := strings.Join(hashes, "|")
+	v.Add("hashes", hv)
+	v.Add("deleteFiles", strconv.FormatBool(deleteFiles))
+
+	encodedHashes := v.Encode()
+
+	resp, err := c.get("torrents/delete?"+encodedHashes, nil)
+	if err != nil {
+		log.Fatalf("error deleting torrents: %v", err)
+	} else if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func (c *Client) ReAnnounceTorrents(hashes []string) error {
+	v := url.Values{}
+
+	// Add hashes together with | separator
+	hv := strings.Join(hashes, "|")
+	v.Add("hashes", hv)
+
+	encodedHashes := v.Encode()
+
+	resp, err := c.get("torrents/reannounce?"+encodedHashes, nil)
+	if err != nil {
+		log.Fatalf("error reannouncing torrent: %v", err)
+	} else if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/pkg/qbittorrent/methods.go
+++ b/pkg/qbittorrent/methods.go
@@ -2,7 +2,6 @@ package qbittorrent
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -106,13 +105,6 @@ func (c *Client) AddTorrentFromFile(file string, options map[string]string) (has
 		log.Fatalf("could not open file %v", err)
 	}
 
-	// Get hash from info
-	torrentHash := metainfo.HashBytes(t.InfoBytes)
-	hash = torrentHash.String()
-	if hash == "" {
-		return "", errors.New("could not stringify torrent hash")
-	}
-
 	res, err := c.postFile("torrents/add", file, options)
 	if err != nil {
 		return "", err
@@ -122,7 +114,7 @@ func (c *Client) AddTorrentFromFile(file string, options map[string]string) (has
 
 	defer res.Body.Close()
 
-	return hash, nil
+	return t.HashInfoBytes().HexString(), nil
 }
 
 func (c *Client) AddTorrentFromMagnet(u string, options map[string]string) (hash string, err error) {


### PR DESCRIPTION
This adds a reannounce check when adding torrents for trackers that are bugged and won't work directly.

And some additional refactoring of the client.