### PR TITLE
Add tags when adding torrents

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Flags:
   * `--skip-hash-check` - Skip hash check
   * `--save-path` - Add torrent to the specified path
   * `--category` - Add torrent to the specified category
+  * `--tags` - Add tags to the torrent. Use multiple or comma-separate tags e.g. --tags linux,iso. Supported in 4.3.2+ 
 
 Add a new torrent to qBittorrent.
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
@@ -20,6 +21,7 @@ func RunAdd() *cobra.Command {
 		skipHashCheck bool
 		savePath      string
 		category      string
+		tags          []string
 	)
 
 	var command = &cobra.Command{
@@ -40,6 +42,7 @@ func RunAdd() *cobra.Command {
 	command.Flags().BoolVar(&skipHashCheck, "skip-hash-check", false, "Skip hash check")
 	command.Flags().StringVar(&savePath, "save-path", "", "Add torrent to the specified path")
 	command.Flags().StringVar(&category, "category", "", "Add torrent to the specified category")
+	command.Flags().StringArrayVar(&tags, "tags", []string{}, "Add tags to torrent")
 
 	command.Run = func(cmd *cobra.Command, args []string) {
 		// args
@@ -72,6 +75,9 @@ func RunAdd() *cobra.Command {
 			}
 			if category != "" {
 				options["category"] = category
+			}
+			if tags != nil {
+				options["tags"] = strings.Join(tags, ",")
 			}
 
 			var res string


### PR DESCRIPTION
⚠️  **Only supported in Qbittorrent 4.3.2+**

Add tags when adding torrents. Supports multiple tags.

```
qbt add file.torrent --tags linux,iso
```

