### PR TITLE
Backup data before import

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ Supported clients:
 
 Optional flags:
 * `--dry-run` - don't write anything to disk
+* `--skip-backup` - skip backup of state dirs before importing data
 
 > WARNING: Make sure to stop both the source client and qBittorrent before importing.
 
 Example with Deluge.
 
-    qbt import --source deluge --source-dir ~/.config/deluge --qbit-dir ~/.local/share/data/qBittorrent/BT_backup
+    qbt import --source deluge --source-dir ~/.config/deluge/state/ --qbit-dir ~/.local/share/data/qBittorrent/BT_backup --dry-run
 
 After the import you will have to manually delete the torrents from the source client, but don't check the "also delete files" as currently the import DOES NOT move the actual data.

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -14,11 +14,11 @@ import (
 // RunImport cmd import torrents
 func RunImport() *cobra.Command {
 	var (
-		source    string
-		sourceDir string
-		qbitDir   string
-		dryRun    bool
-		noBackup  bool
+		source     string
+		sourceDir  string
+		qbitDir    string
+		dryRun     bool
+		skipBackup bool
 	)
 
 	var command = &cobra.Command{
@@ -30,7 +30,7 @@ func RunImport() *cobra.Command {
 	command.Flags().StringVar(&sourceDir, "source-dir", "", "source client state dir")
 	command.Flags().StringVar(&qbitDir, "qbit-dir", "", "qbit dir")
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Run without doing anything")
-	command.Flags().BoolVar(&noBackup, "no-backup", false, "Don't backup before running")
+	command.Flags().BoolVar(&skipBackup, "skip-backup", false, "Skip backup before import. Not advised")
 
 	command.MarkFlagRequired("source")
 	command.MarkFlagRequired("source-dir")
@@ -41,7 +41,7 @@ func RunImport() *cobra.Command {
 		// TODO check if program is running, if true exit
 
 		// Backup data before running
-		if noBackup != true {
+		if skipBackup != true {
 			fmt.Print("Prepare to backup data..\n")
 			t := time.Now().Format("2006-01-02_15-04-05")
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mitchellh/go-homedir"
-
 	"github.com/ludviglundgren/qbittorrent-cli/internal/fs"
-
 	"github.com/ludviglundgren/qbittorrent-cli/internal/importer"
+
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/importer"
+	"github.com/mitchellh/go-homedir"
 
+	"github.com/ludviglundgren/qbittorrent-cli/internal/fs"
+
+	"github.com/ludviglundgren/qbittorrent-cli/internal/importer"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +19,7 @@ func RunImport() *cobra.Command {
 		sourceDir string
 		qbitDir   string
 		dryRun    bool
+		noBackup  bool
 	)
 
 	var command = &cobra.Command{
@@ -27,6 +31,7 @@ func RunImport() *cobra.Command {
 	command.Flags().StringVar(&sourceDir, "source-dir", "", "source client state dir")
 	command.Flags().StringVar(&qbitDir, "qbit-dir", "", "qbit dir")
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Run without doing anything")
+	command.Flags().BoolVar(&noBackup, "no-backup", false, "Don't backup before running")
 
 	command.MarkFlagRequired("source")
 	command.MarkFlagRequired("source-dir")
@@ -36,7 +41,35 @@ func RunImport() *cobra.Command {
 
 		// TODO check if program is running, if true exit
 
-		// TODO backup data before
+		// Backup data before running
+		if noBackup != true {
+			fmt.Print("Prepare to backup data..\n")
+			t := time.Now().Format("2006-01-02_15-04-05")
+
+			homeDir, err := homedir.Dir()
+			if err != nil {
+				fmt.Printf("could not find home directory: %v", err)
+			}
+
+			sourceBackupDir := homeDir + "/qbt_backup/" + source + "_backup_" + t
+			qbitBackupDir := homeDir + "/qbt_backup/qBittorrent_backup_" + t
+
+			fmt.Printf("Backup %v directory: %v ..\n", source, sourceBackupDir)
+			err = fs.CopyDir(sourceDir, sourceBackupDir)
+			if err != nil {
+				fmt.Printf("could not backup directory: %v", err)
+			}
+			fmt.Print("Done!\n")
+
+			fmt.Printf("Backup %v directory: %v .. \n", "qBittorrent", qbitBackupDir)
+			err = fs.CopyDir(qbitDir, qbitBackupDir)
+			if err != nil {
+				fmt.Printf("could not backup directory: %v\n", err)
+			}
+			fmt.Print("Done!\n")
+
+			fmt.Print("Backup done!\n")
+		}
 
 		opts := importer.Options{
 			SourceDir: sourceDir,

--- a/internal/fs/copy.go
+++ b/internal/fs/copy.go
@@ -1,0 +1,111 @@
+package fs
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// CopyFile copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file. The file mode will be copied from the source and
+// the copied data is synced/flushed to stable storage.
+func CopyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if e := out.Close(); e != nil {
+			err = e
+		}
+	}()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return
+	}
+
+	err = out.Sync()
+	if err != nil {
+		return
+	}
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	err = os.Chmod(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CopyDir recursively copies a directory tree, attempting to preserve permissions.
+// Source directory must exist, destination directory must *not* exist.
+// Symlinks are ignored and skipped.
+func CopyDir(src string, dst string) (err error) {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !si.IsDir() {
+		return fmt.Errorf("source is not a directory")
+	}
+
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	if err == nil {
+		return fmt.Errorf("destination already exists")
+	}
+
+	err = os.MkdirAll(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = CopyDir(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		} else {
+			// Skip symlinks.
+			if entry.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+
+			err = CopyFile(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
Backup data of source client and qBittorrent before running import.

Will create backup dirs in `~/qbt_backup` for both source client and qBittorrent.

Add flag `--skip-backup`