### PR TITLE
Overhaul qbt list command to make it more readable

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -53,34 +53,34 @@ func RunList() *cobra.Command {
 				os.Exit(1)
 			}
 
-			PrintList(torrents)
+			printList(torrents)
 		}
 	}
 
 	return command
 }
 
-func PrintList(torrents []qbittorrent.Torrent) {
+func printList(torrents []qbittorrent.Torrent) {
 	for _, torrent := range torrents {
-		fmt.Printf("%-60s\t[%s]\n", torrent.Name, torrent.State)
+		fmt.Printf("%-60s\t[Status: %s]\n", torrent.Name, torrent.State)
 
 		fmt.Printf(
 			"Downloaded: %s / %s%10s",
-			BytesToHumanReadable(float64(torrent.Completed)),
-			BytesToHumanReadable(float64(torrent.TotalSize)),
+			bytesToHumanReadable(float64(torrent.Completed)),
+			bytesToHumanReadable(float64(torrent.TotalSize)),
 			"",
 		)
 
 		if torrent.DlSpeed > 0 {
 			fmt.Printf(
 				"DL Speed: %s/s%10s\t",
-				BytesToHumanReadable(float64(torrent.DlSpeed)),
+				bytesToHumanReadable(float64(torrent.DlSpeed)),
 				"",
 			)
 		} else if torrent.UpSpeed > 0 {
 			fmt.Printf(
 				"UP Speed: %s/s%10s\t",
-				BytesToHumanReadable(float64(torrent.UpSpeed)),
+				bytesToHumanReadable(float64(torrent.UpSpeed)),
 				"",
 			)
 		} else {
@@ -96,7 +96,7 @@ func PrintList(torrents []qbittorrent.Torrent) {
 	}
 }
 
-func BytesToHumanReadable(size float64) string {
+func bytesToHumanReadable(size float64) string {
 	if size <= 0 {
 		return "0.0KB"
 	}

--- a/pkg/qbittorrent/domain.go
+++ b/pkg/qbittorrent/domain.go
@@ -9,7 +9,7 @@ type Torrent struct {
 	Completed          int          `json:"completed"`
 	CompletionOn       int          `json:"completion_on"`
 	DlLimit            int          `json:"dl_limit"`
-	DlSpeed            int          `json:"dl_speed"`
+	DlSpeed            int          `json:"dlspeed"`
 	Downloaded         int          `json:"downloaded"`
 	DownloadedSession  int          `json:"downloaded_session"`
 	ETA                int          `json:"eta"`


### PR DESCRIPTION
Fantastic project you have here, its been super helpful lately! I felt like the qbt list was pretty hard to read so I decided to try and write some of my first Go code to help out!

Screenshot of this PR's current changes (excuse the torrent choices):
![image](https://user-images.githubusercontent.com/59930937/146311983-bf4fb6cd-61cb-4133-8dfd-9be20dfbf62e.png)

These were the properties I found useful to actually be listed, but if you think there are more I missed or something I should remove let me know!

Lastly, I corrected the json property attached to `DlSpeed` from `dl_speed` to `dlspeed`.
