### PR TITLE
qbt hash torrent/magnet to print hash

### DIFF
--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/anacrolix/torrent/metainfo"
+	"github.com/spf13/cobra"
+)
+
+// RunAdd cmd to add torrents
+func RunHash() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "hash",
+		Short: "Print the hash of a torrent/magnet",
+		Example:  `  qbt hash file.torrent`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("requires a torrent file or magnet URI as first argument")
+			}
+
+			return nil
+		},
+	}
+
+	command.Run = func(cmd *cobra.Command, args []string) {
+		filePath := args[0]
+		hash := ""
+		if strings.HasPrefix(filePath, "magnet:") {
+			metadata, err := metainfo.ParseMagnetURI(filePath)
+			if err != nil {
+				log.Fatalf("could not parse magnet URI. error: %v", err)
+			}
+			hash = metadata.InfoHash.HexString()
+		} else {
+			metadata, err := metainfo.LoadFromFile(filePath)
+			if err != nil {
+				log.Fatalf("could not parse torrent file. error: %v", err)
+			}
+			hash = metadata.HashInfoBytes().HexString()
+		}
+		fmt.Println(hash)
+	}
+	return command
+}

--- a/cmd/qbt/main.go
+++ b/cmd/qbt/main.go
@@ -40,6 +40,7 @@ Documentation is available at https://github.com/ludviglundgren/qbittorrent-cli`
 	rootCmd.AddCommand(cmd.RunMove())
 	rootCmd.AddCommand(cmd.RunCompare())
 	rootCmd.AddCommand(cmd.RunEdit())
+	rootCmd.AddCommand(cmd.RunHash())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
i dont think support bittorrentv2 magnet/torrent (not tested)

always print newline after hash (not detect interactive terminal) can be improved but want your reaction first