### PR TITLE
Feature: add "remove" command

### DIFF
--- a/cmd/qbt/main.go
+++ b/cmd/qbt/main.go
@@ -41,6 +41,7 @@ Documentation is available at https://github.com/ludviglundgren/qbittorrent-cli`
 	rootCmd.AddCommand(cmd.RunCompare())
 	rootCmd.AddCommand(cmd.RunEdit())
 	rootCmd.AddCommand(cmd.RunHash())
+	rootCmd.AddCommand(cmd.RunRemove())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"log"
+
+	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
+
+	"github.com/spf13/cobra"
+)
+
+// RunRemove cmd to remove torrents
+func RunRemove() *cobra.Command {
+	var (
+		removeAll		bool
+		deleteFiles		bool
+		hashes			bool 
+		names			bool 
+	)
+
+	var command = &cobra.Command{
+		Use:   "remove",
+		Short: "Removes specified torrents",
+		Long:  `Removes torrents indicated by hash, name or a prefix of either; 
+				whitespace indicates next prefix unless argument is surrounded by quotes`,
+	}
+
+	command.Flags().BoolVar(&removeAll, "all", false, "Removes all torrents")
+	command.Flags().BoolVar(&deleteFiles, "delete-files", false, "Also delete downloaded files from torrent(s)")
+	command.Flags().BoolVar(&hashes, "hashes", false, "Provided arguments will be read as torrent hashes")
+	command.Flags().BoolVar(&names, "names", false, "Provided arguments will be read as torrent names")
+
+	command.Run = func(cmd *cobra.Command, args []string) {
+		if !removeAll && len(args) < 1 {
+			log.Printf("Please provide atleast one torrent hash/name as an argument")
+			return
+		}
+
+		if !removeAll && !hashes && !names {
+			log.Printf("Please specifiy if arguments are to be read as hashes or names (--hashes / --names)")
+			return
+		}
+
+		config.InitConfig()
+		qbtSettings := qbittorrent.Settings{
+			Hostname: config.Qbit.Host,
+			Port:	  config.Qbit.Port,
+			Username: config.Qbit.Login,
+			Password: config.Qbit.Password,
+		}
+		qb := qbittorrent.NewClient(qbtSettings)
+
+		err := qb.Login()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: connection failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		torrents, err := qb.GetTorrents()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: could not retrieve torrents: %v\n", err)
+			os.Exit(1)
+		}
+
+		foundHashes := map[string]bool{}
+		for _, torrent := range torrents {
+			if removeAll {
+				foundHashes[torrent.Hash] = true
+				continue
+			}
+
+			if hashes {
+				for _, targetHash := range args {
+					if strings.HasPrefix(torrent.Hash, targetHash) {
+						foundHashes[torrent.Hash] = true
+						break
+					}
+				}
+			}
+
+			if names {
+				for _, targetName := range args {
+					if strings.HasPrefix(torrent.Name, targetName) {
+						foundHashes[torrent.Hash] = true
+						break
+					}
+				}
+			}
+		}
+
+		hashesToRemove := []string{}
+		for hash := range foundHashes {
+			hashesToRemove = append(hashesToRemove, hash)
+		}
+
+		err = qb.DeleteTorrents(hashesToRemove, deleteFiles)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: could not delete torrents: %v\n", err)
+			os.Exit(1)
+		}
+
+		log.Printf("torrent(s) successfully deleted")
+	}
+
+	return command
+}


### PR DESCRIPTION
This adds a command to remove torrents using either the torrents name or hash. For ease of us you can provide a shortened prefix of the name or hash and it will identify the torrent that begins with that prefix. It inherits its case-sensitive behavior from qbittorrents remove endpoint.

The command has two main flags that dictate behavior, `--hashes` and `--names` which will indicate how the command interprets the arguments given, i.e if both flags are present then each argument will be checked against the torrents names and hashes to find matches. `--all` will remove all torrents, and `--delete-files` will specify to delete the files on the hard drive associated with the torrent.

Examples of the command in use:
`qbt remove --hashes a1eb`
`qbt remove --names "Kali Linux"`
`qbt remove --names --hashes movie` <- this will search for a torrent with a hash of "movie" or a name of "movie"
`qbt remove --all`

In the future I intend to also add very similar functionality to the resume & pause commands, and improve the list command to include hashes and other information, in different PRs.

Thank you and let me know what you think!