### PR TITLE
Feature: add torrent selection for Pause & Resume commands

### DIFF
--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"log"
+	"time"
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
 	"github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
@@ -12,12 +14,34 @@ import (
 
 // RunPause cmd to pause torrents
 func RunPause() *cobra.Command {
+	var (
+		pauseAll	bool
+		hashes		bool
+		names		bool
+	)
+
 	var command = &cobra.Command{
 		Use:   "pause",
-		Short: "Pause all torrents",
-		Long:  `Pause all torrents`,
+		Short: "Pause specified torrents",
+		Long:  `Pauses torrents indicated by hash, name or a prefix of either; 
+				whitespace indicates next prefix unless argument is surrounded by quotes`,
 	}
+
+	command.Flags().BoolVar(&pauseAll, "all", false, "Pauses all torrents")
+	command.Flags().BoolVar(&hashes, "hashes", false, "Provided arguments will be read as torrent hashes")
+	command.Flags().BoolVar(&names, "names", false, "Provided arguments will be read as torrent names")
+
 	command.Run = func(cmd *cobra.Command, args []string) {
+		if !pauseAll && len(args) < 1 {
+			log.Printf("Please provide atleast one torrent hash/name as an argument")
+			return
+		}
+
+		if !pauseAll && !hashes && !names {
+			log.Printf("Please specifiy if arguments are to be read as hashes or names (--hashes / --names)")
+			return
+		}
+
 		config.InitConfig()
 		qbtSettings := qbittorrent.Settings{
 			Hostname: config.Qbit.Host,
@@ -33,11 +57,51 @@ func RunPause() *cobra.Command {
 			os.Exit(1)
 		}
 
-		err = qb.Pause(nil)
+		if pauseAll {
+			qb.Pause([]string{"all"})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: could not pause torrents: %v\n", err)
+				os.Exit(1)
+			}
+
+			log.Printf("All torrents paused successfully")
+			return
+		}
+
+		foundTorrents, err := qb.GetTorrentsByPrefixes(args, hashes, names)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: could not pause torrents %v\n", err)
+			fmt.Fprintf(os.Stderr, "ERROR: failed to retrieve torrents: %v\n", err)
 			os.Exit(1)
 		}
+
+		hashesToPause := []string{}
+		for _, torrent := range foundTorrents {
+			hashesToPause = append(hashesToPause, torrent.Hash)
+		}
+
+		if len(hashesToPause) < 1 {
+			log.Printf("No torrents found to pause with provided search terms")
+			return
+		}
+
+		// Split the hashes to pause into groups of 20 to avoid flooding qbittorrent
+		batch := 20
+		for i := 0; i < len(hashesToPause); i += batch {
+			j := i + batch
+			if j > len(hashesToPause) {
+				j = len(hashesToPause)
+			}
+
+			qb.Pause(hashesToPause[i:j])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: could not pause torrents: %v\n", err)
+				os.Exit(1)
+			}
+
+			time.Sleep(time.Second * 1)
+		}
+
+		log.Printf("torrent(s) successfully paused")
 	}
 
 	return command

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"log"
+	"time"
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
 	"github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
@@ -12,13 +14,34 @@ import (
 
 // RunResume cmd to resume torrents
 func RunResume() *cobra.Command {
+	var (
+		resumeAll	bool
+		hashes		bool
+		names		bool
+	)
+
 	var command = &cobra.Command{
 		Use:   "resume",
-		Short: "Resume all torrents",
-		Long:  `Resume all torrents`,
+		Short: "resume specified torrents",
+		Long:  `resumes torrents indicated by hash, name or a prefix of either; 
+				whitespace indicates next prefix unless argument is surrounded by quotes`,
 	}
 
+	command.Flags().BoolVar(&resumeAll, "all", false, "resumes all torrents")
+	command.Flags().BoolVar(&hashes, "hashes", false, "Provided arguments will be read as torrent hashes")
+	command.Flags().BoolVar(&names, "names", false, "Provided arguments will be read as torrent names")
+
 	command.Run = func(cmd *cobra.Command, args []string) {
+		if !resumeAll && len(args) < 1 {
+			log.Printf("Please provide atleast one torrent hash/name as an argument")
+			return
+		}
+
+		if !resumeAll && !hashes && !names {
+			log.Printf("Please specifiy if arguments are to be read as hashes or names (--hashes / --names)")
+			return
+		}
+
 		config.InitConfig()
 		qbtSettings := qbittorrent.Settings{
 			Hostname: config.Qbit.Host,
@@ -34,11 +57,52 @@ func RunResume() *cobra.Command {
 			os.Exit(1)
 		}
 
-		err = qb.Resume(nil)
+
+		if resumeAll {
+			qb.Resume([]string{"all"})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: could not resume torrents: %v\n", err)
+				os.Exit(1)
+			}
+
+			log.Printf("All torrents resumed successfully")
+			return
+		}
+
+		foundTorrents, err := qb.GetTorrentsByPrefixes(args, hashes, names)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: could not resume torrents %v\n", err)
+			fmt.Fprintf(os.Stderr, "ERROR: failed to retrieve torrents: %v\n", err)
 			os.Exit(1)
 		}
+
+		hashesToResume := []string{}
+		for _, torrent := range foundTorrents {
+			hashesToResume = append(hashesToResume, torrent.Hash)
+		}
+
+		if len(hashesToResume) < 1 {
+			log.Printf("No torrents found to resume with provided search terms")
+			return
+		}
+
+		// Split the hashes to resume into groups of 20 to avoid flooding qbittorrent
+		batch := 20
+		for i := 0; i < len(hashesToResume); i += batch {
+			j := i + batch
+			if j > len(hashesToResume) {
+				j = len(hashesToResume)
+			}
+
+			qb.Resume(hashesToResume[i:j])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: could not resume torrents: %v\n", err)
+				os.Exit(1)
+			}
+
+			time.Sleep(time.Second * 1)
+		}
+
+		log.Printf("torrent(s) successfully resumed")
 	}
 
 	return command


### PR DESCRIPTION
Added the same functionality from newly merged Remove command to Pause & Resume commands.

Same `--hashes --names --all` flags added to both Pause & Resume.

Also did a bit of refactoring of the code to search for torrents using name or hash prefixes, and made it into a method for the qbittorrent client in `methods.go` to be universally used on all of the commands mentioned. `GetTorrentsByPrefixes` accepts a string list of terms to search for, and boolean flags to check against either hashes, names, or both.

( I intend to add categories + tags into these commands with separate functions later :) )