### PR TITLE
Feature: Move only included tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ By using ATM (Automatic Torrent Mode) and the default behavior of categories map
 Optional flags:
 * `--dry-run` - Run without doing anything
 * `--min-seed-time` - Only move torrents with a minimum active seedtime of X minutes
+* `--include-tags` - Only move torrents with any of the tags in comma separate list (tag1,tag2)
 
 Usable with cron as well. Run every 15 min.
 

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -120,7 +120,6 @@ func validateTag(includeTags []string, torrentTags string) bool {
 	for _, includeTag := range includeTags {
 		for _, tag := range tagList {
 			if tag == includeTag {
-				fmt.Printf("Tag match %v\n", tag)
 				return true
 			}
 		}

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -18,6 +18,7 @@ func RunMove() *cobra.Command {
 		dry            bool
 		fromCategories []string
 		targetCategory string
+		includeTags    []string
 		minSeedTime    int
 	)
 
@@ -30,6 +31,7 @@ func RunMove() *cobra.Command {
 	command.Flags().BoolVar(&dry, "dry-run", false, "Run without doing anything")
 	command.Flags().StringSliceVar(&fromCategories, "from", []string{}, "Move from categories")
 	command.Flags().StringVar(&targetCategory, "to", "", "Move to the specified category")
+	command.Flags().StringSliceVar(&includeTags, "include-tags", []string{}, "Move from tags")
 	command.Flags().IntVar(&minSeedTime, "min-seed-time", 0, "Minimum seed time in MINUTES before moving.")
 	command.MarkFlagRequired("from")
 	command.MarkFlagRequired("to")
@@ -65,6 +67,13 @@ func RunMove() *cobra.Command {
 					continue
 				}
 
+				if len(includeTags) > 0 {
+					validTag := validateTag(includeTags, torrent.Tags)
+					if !validTag {
+						continue
+					}
+				}
+
 				// check TimeActive (seconds), CompletionOn (epoch) SeenComplete
 				if minSeedTime > 0 {
 					completedTime := time.Unix(int64(torrent.CompletionOn), 0)
@@ -82,7 +91,7 @@ func RunMove() *cobra.Command {
 		}
 
 		if len(hashes) == 0 {
-			fmt.Printf("Could not find any matching torrents to move from (%v) to (%v) with min-seed-time %d minutes \n", strings.Join(fromCategories, ","), targetCategory, minSeedTime)
+			fmt.Printf("Could not find any matching torrents to move from (%v) to (%v) with tags (%v) and min-seed-time %d minutes \n", strings.Join(fromCategories, ","), targetCategory, strings.Join(includeTags, ","), minSeedTime)
 			os.Exit(0)
 		}
 
@@ -103,4 +112,19 @@ func RunMove() *cobra.Command {
 	}
 
 	return command
+}
+
+func validateTag(includeTags []string, torrentTags string) bool {
+	tagList := strings.Split(torrentTags, ", ")
+
+	for _, includeTag := range includeTags {
+		for _, tag := range tagList {
+			if tag == includeTag {
+				fmt.Printf("Tag match %v\n", tag)
+				return true
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Add flag `--include-tags` to `move` command to only move torrents if tag matches.

`--include-tags` takes a comma separated list of tags eg. `tag1,tag2`