### PR TITLE
Filter qbt list command by torrent state.

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -59,19 +62,26 @@ func RunAdd() *cobra.Command {
 
 		if !dry {
 			qbtSettings := qbittorrent.Settings{
-				Hostname: config.Qbit.Host,
-				Port:     config.Qbit.Port,
-				Username: config.Qbit.Login,
-				Password: config.Qbit.Password,
+				Addr:      config.Qbit.Addr,
+				Hostname:  config.Qbit.Host,
+				Port:      config.Qbit.Port,
+				Username:  config.Qbit.Login,
+				Password:  config.Qbit.Password,
+				BasicUser: config.Qbit.BasicUser,
+				BasicPass: config.Qbit.BasicPass,
 			}
+
 			qb := qbittorrent.NewClient(qbtSettings)
-			err := qb.Login()
-			if err != nil {
-				log.Fatalf("connection failed %v", err)
+
+			ctx := context.Background()
+
+			if err := qb.Login(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: connection failed: %v\n", err)
+				os.Exit(1)
 			}
 
 			if config.Rules.Enabled && !ignoreRules {
-				activeDownloads, err := qb.GetTorrentsFilter(qbittorrent.TorrentFilterDownloading)
+				activeDownloads, err := qb.GetTorrentsFilter(ctx, qbittorrent.TorrentFilterDownloading)
 				if err != nil {
 					log.Fatalf("could not fetch torrents: %v", err)
 				}
@@ -106,18 +116,19 @@ func RunAdd() *cobra.Command {
 			}
 
 			var res string
+			var err error
 			if magnet {
-				res, err = qb.AddTorrentFromMagnet(filePath, options)
+				res, err = qb.AddTorrentFromMagnet(ctx, filePath, options)
 			} else {
-				res, err = qb.AddTorrentFromFile(filePath, options)
+				res, err = qb.AddTorrentFromFile(ctx, filePath, options)
 			}
 			if err != nil {
 				log.Fatalf("adding torrent failed: %v", err)
 			}
 
-			// some trackers are bugged or slow so we need to re-announce the torrent until it works
+			// some trackers are bugged or slow, so we need to re-announce the torrent until it works
 			if config.Reannounce.Enabled && !paused {
-				err = checkTrackerStatus(*qb, res)
+				err = checkTrackerStatus(ctx, qb, res)
 				if err != nil {
 					log.Fatalf("could not get tracker status for torrent: %v", err)
 				}
@@ -132,14 +143,14 @@ func RunAdd() *cobra.Command {
 	return command
 }
 
-func checkTrackerStatus(qb qbittorrent.Client, hash string) error {
+func checkTrackerStatus(ctx context.Context, qb *qbittorrent.Client, hash string) error {
 	announceOK := false
 	attempts := 0
 
 	time.Sleep(time.Duration(config.Reannounce.Interval) * time.Millisecond)
 
 	for attempts < config.Reannounce.Attempts {
-		trackers, err := qb.GetTorrentTrackers(hash)
+		trackers, err := qb.GetTorrentTrackers(ctx, hash)
 		if err != nil {
 			log.Fatalf("could not get trackers of torrent: %v %v", hash, err)
 		}
@@ -148,7 +159,7 @@ func checkTrackerStatus(qb qbittorrent.Client, hash string) error {
 		_, working := findTrackerStatus(trackers, 2)
 
 		if !working {
-			err = qb.ReAnnounceTorrents([]string{hash})
+			err = qb.ReAnnounceTorrents(ctx, []string{hash})
 			if err != nil {
 				return err
 			}
@@ -164,7 +175,7 @@ func checkTrackerStatus(qb qbittorrent.Client, hash string) error {
 
 	if !announceOK {
 		log.Println("Announce not ok, deleting torrent")
-		err := qb.DeleteTorrents([]string{hash}, false)
+		err := qb.DeleteTorrents(ctx, []string{hash}, false)
 		if err != nil {
 			return err
 		}
@@ -175,11 +186,12 @@ func checkTrackerStatus(qb qbittorrent.Client, hash string) error {
 
 // Check if status not working or something else
 // https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
-//  0 Tracker is disabled (used for DHT, PeX, and LSD)
-//  1 Tracker has not been contacted yet
-//  2 Tracker has been contacted and is working
-//  3 Tracker is updating
-//  4 Tracker has been contacted, but it is not working (or doesn't send proper replies)
+//
+//	0 Tracker is disabled (used for DHT, PeX, and LSD)
+//	1 Tracker has not been contacted yet
+//	2 Tracker has been contacted and is working
+//	3 Tracker is updating
+//	4 Tracker has been contacted, but it is not working (or doesn't send proper replies)
 func findTrackerStatus(slice []qbittorrent.TorrentTracker, val int) (int, bool) {
 	for i, item := range slice {
 		if item.Status == val {

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -86,7 +86,7 @@ func RunEdit() *cobra.Command {
 }
 
 func processFastResume(path, pattern, replace string, verbose, dry bool) error {
-	read, err := ioutil.ReadFile(path)
+	read, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("error reading file: %v - %v", path, err)
 	}

--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -10,12 +10,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RunAdd cmd to add torrents
+// RunHash cmd to add torrents
 func RunHash() *cobra.Command {
 	var command = &cobra.Command{
-		Use:   "hash",
-		Short: "Print the hash of a torrent/magnet",
-		Example:  `  qbt hash file.torrent`,
+		Use:     "hash",
+		Short:   "Print the hash of a torrent/magnet",
+		Example: `  qbt hash file.torrent`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("requires a torrent file or magnet URI as first argument")
@@ -29,7 +29,7 @@ func RunHash() *cobra.Command {
 		filePath := args[0]
 		hash := ""
 		if strings.HasPrefix(filePath, "magnet:") {
-			metadata, err := metainfo.ParseMagnetURI(filePath)
+			metadata, err := metainfo.ParseMagnetUri(filePath)
 			if err != nil {
 				log.Fatalf("could not parse magnet URI. error: %v", err)
 			}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,7 +19,7 @@ func RunList() *cobra.Command {
 	var (
 		filter     = "all"
 		category   string
-		tags       string
+		tag        string
 		hashes     string
 		outputJson bool
 	)
@@ -27,13 +27,13 @@ func RunList() *cobra.Command {
 	var command = &cobra.Command{
 		Use:     "list",
 		Short:   "List torrents",
-		Long:    `List all torrents, or torrents with a specific filters. Get by filter, category, tags and hashes. Can be combined`,
+		Long:    `List all torrents, or torrents with a specific filters. Get by filter, category, tag and hashes. Can be combined`,
 		Example: `qbt list --filter=downloading --category=linux-iso`,
 	}
 	command.Flags().BoolVar(&outputJson, "json", false, "Print to json")
 	command.Flags().StringVarP(&filter, "filter", "f", "all", "Filter by state. Available filters: all, downloading, seeding, completed, paused, active, inactive, resumed, \nstalled, stalled_uploading, stalled_downloading, errored")
 	command.Flags().StringVarP(&category, "category", "c", "", "Filter by category. All categories by default.")
-	command.Flags().StringVarP(&tags, "tags", "t", "", "Filter by tags. Comma separated list: tag1,tag2")
+	command.Flags().StringVarP(&tag, "tag", "t", "", "Filter by tag. Single tag: tag1")
 	command.Flags().StringVarP(&hashes, "hashes", "h", "", "Filter by hashes. Separated by | pipe: \"hash1|hash2\".")
 
 	command.Run = func(cmd *cobra.Command, args []string) {
@@ -60,7 +60,8 @@ func RunList() *cobra.Command {
 		req := qbittorrent.GetTorrentsRequest{
 			Filter:   strings.ToLower(filter),
 			Category: category,
-			Tags:     tags,
+			Tag:      tag,
+			Hashes:   hashes,
 		}
 
 		// get torrent list with default filter of all

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,10 +1,13 @@
 package domain
 
 type QbitConfig struct {
-	Host     string `mapstructure:"host"`
-	Port     uint   `mapstructure:"port"`
-	Login    string `mapstructure:"login"`
-	Password string `mapstructure:"password"`
+	Addr      string `mapstructure:"addr"`
+	Host      string `mapstructure:"host"`
+	Port      uint   `mapstructure:"port"`
+	Login     string `mapstructure:"login"`
+	Password  string `mapstructure:"password"`
+	BasicUser string `mapstructure:"basicUser"`
+	BasicPass string `mapstructure:"basicPass"`
 }
 
 type ReannounceSettings struct {

--- a/pkg/qbittorrent/client.go
+++ b/pkg/qbittorrent/client.go
@@ -2,6 +2,7 @@ package qbittorrent
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
@@ -13,19 +14,33 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 	"golang.org/x/net/publicsuffix"
 )
 
 type Client struct {
-	settings Settings
-	http     *http.Client
+	hostname      string
+	port          uint
+	addr          string
+	username      string
+	password      string
+	basicUser     string
+	basicPass     string
+	tlsSkipVerify bool
+
+	http *http.Client
 }
 
 type Settings struct {
-	Hostname string
-	Port     uint
-	Username string
-	Password string
+	Hostname      string
+	Port          uint
+	Addr          string
+	Username      string
+	Password      string
+	BasicUser     string
+	BasicPass     string
+	TLSSkipVerify bool
 }
 
 func NewClient(s Settings) *Client {
@@ -35,23 +50,74 @@ func NewClient(s Settings) *Client {
 	if err != nil {
 		log.Fatal(err)
 	}
-	httpClient := &http.Client{
-		Timeout: time.Second * 10,
-		Jar:     jar,
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: s.TLSSkipVerify,
+		},
 	}
+
+	httpClient := &http.Client{
+		Timeout:   time.Second * 10,
+		Jar:       jar,
+		Transport: t,
+	}
+
 	return &Client{
-		settings: s,
-		http:     httpClient,
+		hostname:      s.Hostname,
+		port:          s.Port,
+		addr:          s.Addr,
+		username:      s.Username,
+		password:      s.Password,
+		basicUser:     s.BasicUser,
+		basicPass:     s.BasicPass,
+		tlsSkipVerify: s.TLSSkipVerify,
+		http:          httpClient,
 	}
 }
 
 func (c *Client) get(endpoint string, opts map[string]string) (*http.Response, error) {
-	reqUrl := fmt.Sprintf("http://%v:%v/api/v2/%v", c.settings.Hostname, c.settings.Port, endpoint)
+	reqUrl, err := c.buildUrl(endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	req, err := http.NewRequest("GET", reqUrl, nil)
+	req, err := http.NewRequest(http.MethodGet, reqUrl, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	// set basic auth
+	c.setBasicAuth(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (c *Client) getCtx(ctx context.Context, endpoint string, values url.Values) (*http.Response, error) {
+	reqUrl, err := c.buildUrl(endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	u, err := url.Parse(reqUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	u.RawQuery = values.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// set basic auth
+	c.setBasicAuth(req)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -70,14 +136,21 @@ func (c *Client) post(endpoint string, opts map[string]string) (*http.Response, 
 		}
 	}
 
-	reqUrl := fmt.Sprintf("http://%v:%v/api/v2/%v", c.settings.Hostname, c.settings.Port, endpoint)
-	req, err := http.NewRequest("POST", reqUrl, strings.NewReader(form.Encode()))
+	reqUrl, err := c.buildUrl(endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, reqUrl, strings.NewReader(form.Encode()))
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// add the content-type so qbittorrent knows what to expect
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	// set basic auth
+	c.setBasicAuth(req)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -89,7 +162,42 @@ func (c *Client) post(endpoint string, opts map[string]string) (*http.Response, 
 	return resp, nil
 }
 
-func (c *Client) postFile(endpoint string, fileName string, opts map[string]string) (*http.Response, error) {
+func (c *Client) postCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
+	// add optional parameters that the user wants
+	form := url.Values{}
+	if opts != nil {
+		for k, v := range opts {
+			form.Add(k, v)
+		}
+	}
+
+	reqUrl, err := c.buildUrl(endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqUrl, strings.NewReader(form.Encode()))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// add the content-type so qbittorrent knows what to expect
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	// set basic auth
+	c.setBasicAuth(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	return resp, nil
+}
+
+func (c *Client) postFileCtx(ctx context.Context, endpoint string, fileName string, opts map[string]string) (*http.Response, error) {
 	file, err := os.Open(fileName)
 	if err != nil {
 		log.Fatalf("error opening file: %v", err)
@@ -133,8 +241,12 @@ func (c *Client) postFile(endpoint string, fileName string, opts map[string]stri
 	// Close multipart writer
 	multiPartWriter.Close()
 
-	reqUrl := fmt.Sprintf("http://%v:%v/api/v2/%v", c.settings.Hostname, c.settings.Port, endpoint)
-	req, err := http.NewRequest("POST", reqUrl, &requestBody)
+	reqUrl, err := c.buildUrl(endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqUrl, &requestBody)
 	if err != nil {
 		log.Fatalf("could not create request object %v", err)
 	}
@@ -142,10 +254,32 @@ func (c *Client) postFile(endpoint string, fileName string, opts map[string]stri
 	// Set correct content type
 	req.Header.Set("Content-Type", multiPartWriter.FormDataContentType())
 
+	// set basic auth
+	c.setBasicAuth(req)
+
 	res, err := c.http.Do(req)
 	if err != nil {
 		log.Fatalf("could not perform request %v", err)
 	}
 
 	return res, nil
+}
+
+func (c *Client) buildUrl(endpoint string) (string, error) {
+	reqUrl, err := url.JoinPath(c.addr, "/api/v2", endpoint)
+	if err != nil {
+		return "", errors.Wrap(err, "could not build addr")
+	}
+
+	if c.hostname != "" && c.port != 0 {
+		reqUrl = fmt.Sprintf("http://%s:%d/api/v2/%s", c.hostname, c.port, endpoint)
+	}
+
+	return reqUrl, nil
+}
+
+func (c *Client) setBasicAuth(req *http.Request) {
+	if c.basicUser != "" && c.basicPass != "" {
+		req.SetBasicAuth(c.basicUser, c.basicPass)
+	}
 }

--- a/pkg/qbittorrent/domain.go
+++ b/pkg/qbittorrent/domain.go
@@ -181,7 +181,7 @@ const (
 type GetTorrentsRequest struct {
 	Filter   string
 	Category string
-	Tags     string
+	Tag      string
 	Hashes   string
 	Json     bool
 }

--- a/pkg/qbittorrent/domain.go
+++ b/pkg/qbittorrent/domain.go
@@ -163,6 +163,9 @@ const (
 	// Torrent is stalled
 	TorrentFilterStalled TorrentFilter = "stalled"
 
+	// Torrent is being seeded and data is being transferred
+	TorrentFilterUploading TorrentFilter = "uploading"
+
 	// Torrent is being seeded, but no connection were made
 	TorrentFilterStalledUploading TorrentFilter = "stalled_uploading"
 
@@ -174,3 +177,11 @@ const (
 
 	TorrentFilterErrored TorrentFilter = "errored"
 )
+
+type GetTorrentsRequest struct {
+	Filter   string
+	Category string
+	Tags     string
+	Hashes   string
+	Json     bool
+}

--- a/pkg/qbittorrent/domain.go
+++ b/pkg/qbittorrent/domain.go
@@ -135,6 +135,7 @@ const (
 	TorrentStateUnknown TorrentState = "unknown"
 )
 
+// https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-list
 type TorrentFilter string
 
 const (
@@ -162,9 +163,6 @@ const (
 	// Torrent is stalled
 	TorrentFilterStalled TorrentFilter = "stalled"
 
-	// Torrent is being seeded and data is being transferred
-	TorrentFilterUploading TorrentFilter = "uploading"
-
 	// Torrent is being seeded, but no connection were made
 	TorrentFilterStalledUploading TorrentFilter = "stalled_uploading"
 
@@ -173,4 +171,6 @@ const (
 
 	// Torrent is being downloaded, but no connection were made
 	TorrentFilterStalledDownloading TorrentFilter = "stalled_downloading"
+
+	TorrentFilterErrored TorrentFilter = "errored"
 )

--- a/pkg/qbittorrent/methods.go
+++ b/pkg/qbittorrent/methods.go
@@ -2,7 +2,6 @@ package qbittorrent
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"io"
 	"log"
 	"net/http"
@@ -10,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/anacrolix/torrent/metainfo"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 func (c *Client) Login(ctx context.Context) error {
@@ -43,6 +42,8 @@ func (c *Client) GetTorrentsWithFilters(ctx context.Context, req *GetTorrentsReq
 		v.Add("filter", req.Filter)
 	} else if req.Category != "" {
 		v.Add("category", req.Category)
+	} else if req.Tag != "" {
+		v.Add("tag", req.Tag)
 	} else if req.Hashes != "" {
 		v.Add("hashes", req.Hashes)
 	}

--- a/pkg/qbittorrent/methods.go
+++ b/pkg/qbittorrent/methods.go
@@ -2,22 +2,25 @@ package qbittorrent
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"github.com/pkg/errors"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/anacrolix/torrent/metainfo"
 )
 
-func (c *Client) Login() error {
+func (c *Client) Login(ctx context.Context) error {
 	credentials := make(map[string]string)
-	credentials["username"] = c.settings.Username
-	credentials["password"] = c.settings.Password
+	credentials["username"] = c.username
+	credentials["password"] = c.password
 
-	resp, err := c.post("auth/login", credentials)
+	resp, err := c.postCtx(ctx, "auth/login", credentials)
 	if err != nil {
 		log.Fatalf("login error: %v", err)
 	} else if resp.StatusCode != http.StatusOK { // check for correct status code
@@ -33,17 +36,48 @@ func (c *Client) Login() error {
 	return nil
 }
 
-func (c *Client) GetTorrents() ([]Torrent, error) {
+func (c *Client) GetTorrentsWithFilters(ctx context.Context, req *GetTorrentsRequest) ([]Torrent, error) {
+	v := url.Values{}
+
+	if req.Filter != "" {
+		v.Add("filter", req.Filter)
+	} else if req.Category != "" {
+		v.Add("category", req.Category)
+	} else if req.Hashes != "" {
+		v.Add("hashes", req.Hashes)
+	}
+
+	resp, err := c.getCtx(ctx, "torrents/info", v)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not fetch torrents")
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read body")
+	}
+
+	var torrents []Torrent
+	if err = json.Unmarshal(body, &torrents); err != nil {
+		return nil, errors.Wrap(err, "could not unmarshal torrents list")
+	}
+
+	return torrents, nil
+}
+
+func (c *Client) GetTorrents(ctx context.Context) ([]Torrent, error) {
 	var torrents []Torrent
 
-	resp, err := c.get("torrents/info", nil)
+	resp, err := c.getCtx(ctx, "torrents/info", nil)
 	if err != nil {
 		log.Fatalf("error fetching torrents: %v", err)
 	}
 
 	defer resp.Body.Close()
 
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		log.Fatal(readErr)
 	}
@@ -56,21 +90,21 @@ func (c *Client) GetTorrents() ([]Torrent, error) {
 	return torrents, nil
 }
 
-func (c *Client) GetTorrentsFilter(filter TorrentFilter) ([]Torrent, error) {
+func (c *Client) GetTorrentsFilter(ctx context.Context, filter TorrentFilter) ([]Torrent, error) {
 	var torrents []Torrent
 
 	v := url.Values{}
 	v.Add("filter", string(filter))
 	params := v.Encode()
 
-	resp, err := c.get("torrents/info?"+params, nil)
+	resp, err := c.getCtx(ctx, "torrents/info?"+params, nil)
 	if err != nil {
 		log.Fatalf("error fetching torrents: %v", err)
 	}
 
 	defer resp.Body.Close()
 
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		log.Fatal(readErr)
 	}
@@ -83,7 +117,7 @@ func (c *Client) GetTorrentsFilter(filter TorrentFilter) ([]Torrent, error) {
 	return torrents, nil
 }
 
-func (c *Client) GetTorrentsByCategory(category string) ([]Torrent, error) {
+func (c *Client) GetTorrentsByCategory(ctx context.Context, category string) ([]Torrent, error) {
 	var torrents []Torrent
 
 	v := url.Values{}
@@ -91,14 +125,14 @@ func (c *Client) GetTorrentsByCategory(category string) ([]Torrent, error) {
 	v.Add("category", category)
 	params := v.Encode()
 
-	resp, err := c.get("torrents/info?"+params, nil)
+	resp, err := c.getCtx(ctx, "torrents/info?"+params, nil)
 	if err != nil {
 		log.Fatalf("error fetching torrents: %v", err)
 	}
 
 	defer resp.Body.Close()
 
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		log.Fatal(readErr)
 	}
@@ -111,77 +145,80 @@ func (c *Client) GetTorrentsByCategory(category string) ([]Torrent, error) {
 	return torrents, nil
 }
 
-func (c *Client) GetTorrentsRaw() (string, error) {
-	resp, err := c.get("torrents/info", nil)
+func (c *Client) GetTorrentsRaw(ctx context.Context) (string, error) {
+	resp, err := c.getCtx(ctx, "torrents/info", nil)
 	if err != nil {
 		log.Fatalf("error fetching torrents: %v", err)
 	}
 
 	defer resp.Body.Close()
 
-	data, _ := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("error fetching torrents: %v", err)
+	}
 
 	return string(data), nil
 }
 
-func (c *Client) GetTorrentByHash(hash string) (string, error) {
+func (c *Client) GetTorrentByHash(ctx context.Context, hash string) (string, error) {
 	v := url.Values{}
 	v.Add("hashes", hash)
 	params := v.Encode()
 
-	resp, err := c.get("torrents/info?"+params, nil)
+	resp, err := c.getCtx(ctx, "torrents/info?"+params, nil)
 	if err != nil {
 		log.Fatalf("error fetching torrents: %v", err)
 	}
 
 	defer resp.Body.Close()
 
-	data, _ := ioutil.ReadAll(resp.Body)
+	data, _ := io.ReadAll(resp.Body)
 
 	return string(data), nil
 }
 
-// Search for torrents using provided prefixes; checks against either hashes, names, or both
-func (c *Client) GetTorrentsByPrefixes(terms []string, hashes bool, names bool) ([]Torrent, error) {
-		torrents, err := c.GetTorrents()
-		if err != nil {
-			log.Fatalf("ERROR: could not retrieve torrents: %v\n", err)
-		}
+// GetTorrentsByPrefixes Search for torrents using provided prefixes; checks against either hashes, names, or both
+func (c *Client) GetTorrentsByPrefixes(ctx context.Context, terms []string, hashes bool, names bool) ([]Torrent, error) {
+	torrents, err := c.GetTorrents(ctx)
+	if err != nil {
+		log.Fatalf("ERROR: could not retrieve torrents: %v\n", err)
+	}
 
-		matchedTorrents := map[Torrent]bool{}
-		for _, torrent := range torrents {
-			if hashes {
-				for _, targetHash := range terms {
-					if strings.HasPrefix(torrent.Hash, targetHash) {
-						matchedTorrents[torrent] = true
-						break
-					}
-				}
-
-				if matchedTorrents[torrent] {
-					continue
+	matchedTorrents := map[Torrent]bool{}
+	for _, torrent := range torrents {
+		if hashes {
+			for _, targetHash := range terms {
+				if strings.HasPrefix(torrent.Hash, targetHash) {
+					matchedTorrents[torrent] = true
+					break
 				}
 			}
 
-			if names {
-				for _, targetName := range terms {
-					if strings.HasPrefix(torrent.Name, targetName) {
-						matchedTorrents[torrent] = true
-						break
-					}
-				}
+			if matchedTorrents[torrent] {
+				continue
 			}
 		}
 
-		var foundTorrents []Torrent
-		for torrent := range matchedTorrents {
-			foundTorrents = append(foundTorrents, torrent)
+		if names {
+			for _, targetName := range terms {
+				if strings.HasPrefix(torrent.Name, targetName) {
+					matchedTorrents[torrent] = true
+					break
+				}
+			}
 		}
+	}
 
-		return foundTorrents, nil
+	var foundTorrents []Torrent
+	for torrent := range matchedTorrents {
+		foundTorrents = append(foundTorrents, torrent)
+	}
+
+	return foundTorrents, nil
 }
 
-func (c *Client) GetTorrentTrackers(hash string) ([]TorrentTracker, error) {
+func (c *Client) GetTorrentTrackers(ctx context.Context, hash string) ([]TorrentTracker, error) {
 	var trackers []TorrentTracker
 
 	params := url.Values{}
@@ -189,14 +226,14 @@ func (c *Client) GetTorrentTrackers(hash string) ([]TorrentTracker, error) {
 
 	p := params.Encode()
 
-	resp, err := c.get("torrents/trackers?"+p, nil)
+	resp, err := c.getCtx(ctx, "torrents/trackers?"+p, nil)
 	if err != nil {
 		log.Fatalf("error fetching torrents: %v", err)
 	}
 
 	defer resp.Body.Close()
 
-	body, readErr := ioutil.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		log.Fatal(readErr)
 	}
@@ -210,14 +247,14 @@ func (c *Client) GetTorrentTrackers(hash string) ([]TorrentTracker, error) {
 }
 
 // AddTorrentFromFile add new torrent from torrent file
-func (c *Client) AddTorrentFromFile(file string, options map[string]string) (hash string, err error) {
+func (c *Client) AddTorrentFromFile(ctx context.Context, file string, options map[string]string) (hash string, err error) {
 	// Get meta info from file to find out the hash for later use
 	t, err := metainfo.LoadFromFile(file)
 	if err != nil {
 		log.Fatalf("could not open file %v", err)
 	}
 
-	res, err := c.postFile("torrents/add", file, options)
+	res, err := c.postFileCtx(ctx, "torrents/add", file, options)
 	if err != nil {
 		return "", err
 	} else if res.StatusCode != http.StatusOK {
@@ -229,14 +266,14 @@ func (c *Client) AddTorrentFromFile(file string, options map[string]string) (has
 	return t.HashInfoBytes().HexString(), nil
 }
 
-func (c *Client) AddTorrentFromMagnet(u string, options map[string]string) (hash string, err error) {
-	m, err := metainfo.ParseMagnetURI(u)
+func (c *Client) AddTorrentFromMagnet(ctx context.Context, u string, options map[string]string) (hash string, err error) {
+	m, err := metainfo.ParseMagnetUri(u)
 	if err != nil {
 		log.Fatalf("could not parse magnet URI %v", err)
 	}
 
 	options["urls"] = u
-	res, err := c.post("torrents/add", options)
+	res, err := c.postCtx(ctx, "torrents/add", options)
 	if err != nil {
 		return "", err
 	} else if res.StatusCode != http.StatusOK {
@@ -248,7 +285,7 @@ func (c *Client) AddTorrentFromMagnet(u string, options map[string]string) (hash
 	return m.InfoHash.HexString(), nil
 }
 
-func (c *Client) DeleteTorrents(hashes []string, deleteFiles bool) error {
+func (c *Client) DeleteTorrents(ctx context.Context, hashes []string, deleteFiles bool) error {
 	v := url.Values{}
 
 	// Add hashes together with | separator
@@ -258,7 +295,7 @@ func (c *Client) DeleteTorrents(hashes []string, deleteFiles bool) error {
 
 	encodedHashes := v.Encode()
 
-	resp, err := c.get("torrents/delete?"+encodedHashes, nil)
+	resp, err := c.postCtx(ctx, "torrents/delete?"+encodedHashes, nil)
 	if err != nil {
 		log.Fatalf("error deleting torrents: %v", err)
 	} else if resp.StatusCode != http.StatusOK {
@@ -270,7 +307,7 @@ func (c *Client) DeleteTorrents(hashes []string, deleteFiles bool) error {
 	return nil
 }
 
-func (c *Client) ReAnnounceTorrents(hashes []string) error {
+func (c *Client) ReAnnounceTorrents(ctx context.Context, hashes []string) error {
 	v := url.Values{}
 
 	// Add hashes together with | separator
@@ -279,7 +316,7 @@ func (c *Client) ReAnnounceTorrents(hashes []string) error {
 
 	encodedHashes := v.Encode()
 
-	resp, err := c.get("torrents/reannounce?"+encodedHashes, nil)
+	resp, err := c.postCtx(ctx, "torrents/reannounce?"+encodedHashes, nil)
 	if err != nil {
 		log.Fatalf("error reannouncing torrent: %v", err)
 	} else if resp.StatusCode != http.StatusOK {
@@ -291,7 +328,7 @@ func (c *Client) ReAnnounceTorrents(hashes []string) error {
 	return nil
 }
 
-func (c *Client) Pause(hashes []string) error {
+func (c *Client) Pause(ctx context.Context, hashes []string) error {
 	v := url.Values{}
 
 	// Add hashes together with | separator
@@ -300,7 +337,7 @@ func (c *Client) Pause(hashes []string) error {
 
 	encodedHashes := v.Encode()
 
-	resp, err := c.get("torrents/pause?"+encodedHashes, nil)
+	resp, err := c.postCtx(ctx, "torrents/pause?"+encodedHashes, nil)
 	if err != nil {
 		log.Fatalf("error pausing torrents: %v", err)
 	} else if resp.StatusCode != http.StatusOK {
@@ -312,7 +349,7 @@ func (c *Client) Pause(hashes []string) error {
 	return nil
 }
 
-func (c *Client) Resume(hashes []string) error {
+func (c *Client) Resume(ctx context.Context, hashes []string) error {
 	v := url.Values{}
 
 	// Add hashes together with | separator
@@ -321,7 +358,7 @@ func (c *Client) Resume(hashes []string) error {
 
 	encodedHashes := v.Encode()
 
-	resp, err := c.get("torrents/resume?"+encodedHashes, nil)
+	resp, err := c.postCtx(ctx, "torrents/resume?"+encodedHashes, nil)
 	if err != nil {
 		log.Fatalf("error resuming torrents: %v", err)
 	} else if resp.StatusCode != http.StatusOK {
@@ -333,7 +370,7 @@ func (c *Client) Resume(hashes []string) error {
 	return nil
 }
 
-func (c *Client) SetCategory(hashes []string, category string) error {
+func (c *Client) SetCategory(ctx context.Context, hashes []string, category string) error {
 	v := url.Values{}
 	encodedHashes := ""
 
@@ -348,7 +385,7 @@ func (c *Client) SetCategory(hashes []string, category string) error {
 	v.Add("category", category)
 	encodedHashes = v.Encode()
 
-	resp, err := c.get("torrents/setCategory?"+encodedHashes, nil)
+	resp, err := c.postCtx(ctx, "torrents/setCategory?"+encodedHashes, nil)
 	if err != nil {
 		log.Fatalf("error resuming torrents: %v", err)
 	} else if resp.StatusCode != http.StatusOK {
@@ -360,7 +397,7 @@ func (c *Client) SetCategory(hashes []string, category string) error {
 	return nil
 }
 
-func (c *Client) SetTag(hashes []string, tag string) error {
+func (c *Client) SetTag(ctx context.Context, hashes []string, tag string) error {
 	v := url.Values{}
 	encodedHashes := ""
 
@@ -375,7 +412,7 @@ func (c *Client) SetTag(hashes []string, tag string) error {
 	v.Add("tags", tag)
 	encodedHashes = v.Encode()
 
-	resp, err := c.get("torrents/addTags?"+encodedHashes, nil)
+	resp, err := c.postCtx(ctx, "torrents/addTags?"+encodedHashes, nil)
 	if err != nil {
 		log.Fatalf("error resuming torrents: %v", err)
 	} else if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
Allows for the `qbt list` command to be filtered to list only the torrents specified by a state argument, like `downloading`.

For example:
`qbt list --filter=active` will list all active torrents currently downloading or uploading.
`qbt list` will continue to list all torrents.

New flags:

* `--filter,-f - takes a single qbit state as filter`
* `--category,-c - takes a single category`
* `--tag,-t - takes a single tag`
* `--hashes,-h - takes one or multiple hashes separated by | pipe: "hash1|hash2"`

Also removed the `uploading` TorrentFilter from `domains.go` since it is not a valid filter for the qbittorrent api, and added the missing `errored` filter.  (https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-list)

Fixes #46