### PR TITLE
feat(export): write export manifest

### DIFF
--- a/cmd/torrent_export_test.go
+++ b/cmd/torrent_export_test.go
@@ -1,12 +1,15 @@
 package cmd
 
-import "testing"
+import (
+	"github.com/autobrr/go-qbittorrent"
+	"testing"
+)
 
 func Test_export_processHashes(t *testing.T) {
 	type args struct {
 		sourceDir string
 		exportDir string
-		hashes    map[string]struct{}
+		hashes    map[string]qbittorrent.Torrent
 		dry       bool
 		verbose   bool
 	}
@@ -20,7 +23,7 @@ func Test_export_processHashes(t *testing.T) {
 			args: args{
 				sourceDir: "../test/config/qBittorrent/BT_backup",
 				exportDir: "../test/export",
-				hashes: map[string]struct{}{
+				hashes: map[string]qbittorrent.Torrent{
 					"5ba4939a00a9b21629a0ad7d376898b768d997a3": {},
 				},
 				dry: false,

--- a/cmd/torrent_pause.go
+++ b/cmd/torrent_pause.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
 
@@ -59,20 +58,13 @@ func RunTorrentPause() *cobra.Command {
 			return
 		}
 
-		// Split the hashes into groups of 20 to avoid flooding qbittorrent
-		batch := 20
-		for i := 0; i < len(hashes); i += batch {
-			j := i + batch
-			if j > len(hashes) {
-				j = len(hashes)
-			}
-
-			if err := qb.PauseCtx(ctx, hashes[i:j]); err != nil {
-				fmt.Fprintf(os.Stderr, "ERROR: could not pause torrents: %v\n", err)
-				os.Exit(1)
-			}
-
-			time.Sleep(time.Second * 1)
+		err := batchRequests(hashes, func(start, end int) error {
+			return qb.PauseCtx(ctx, hashes[start:end])
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not pause torrents: %v\n", err)
+			os.Exit(1)
+			return
 		}
 
 		log.Printf("torrent(s) successfully paused")


### PR DESCRIPTION
Write manifest for torrent export which collects affected hashes, categories and tags to later be used in an import from qbit feature.