### PR TITLE
fix(torrent): remove with only filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Or with only go
 
 Builds with `goreleaser` will also include version info.
 
-    goreleaser release --snapshot --skip-publish --clean
+    goreleaser release --snapshot --skip=publish --clean
 
 ## Configuration
 

--- a/cmd/torrent_remove.go
+++ b/cmd/torrent_remove.go
@@ -33,9 +33,9 @@ func RunTorrentRemove() *cobra.Command {
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Display what would be done without actually doing it")
 	command.Flags().BoolVar(&removeAll, "all", false, "Removes all torrents")
 	command.Flags().BoolVar(&deleteFiles, "delete-files", false, "Also delete downloaded files from torrent(s)")
-	command.Flags().StringVar(&filter, "filter", "", "Filter by state: all, active, paused, completed, stalled, errored")
+	command.Flags().StringVarP(&filter, "filter", "f", "", "Filter by state: all, active, paused, completed, stalled, errored")
 	command.Flags().StringSliceVar(&hashes, "hashes", []string{}, "Add hashes as comma separated list")
-	command.Flags().StringSliceVar(&includeCategory, "include-category", []string{}, "Remove torrents from these categories. Comma separated")
+	command.Flags().StringSliceVarP(&includeCategory, "include-category", "c", []string{}, "Remove torrents from these categories. Comma separated")
 	command.Flags().StringSliceVar(&includeTags, "include-tags", []string{}, "Include torrents with provided tags")
 	command.Flags().StringSliceVar(&excludeTags, "exclude-tags", []string{}, "Exclude torrents with provided tags")
 

--- a/cmd/torrent_remove.go
+++ b/cmd/torrent_remove.go
@@ -66,6 +66,9 @@ func RunTorrentRemove() *cobra.Command {
 		options := qbittorrent.TorrentFilterOptions{}
 		if filter != "" {
 			options.Filter = qbittorrent.TorrentFilter(filter)
+			if len(includeCategory) == 0 {
+				includeCategory = []string{""}
+			}
 		}
 
 		if len(includeCategory) > 0 {


### PR DESCRIPTION
Removing torrents with only a filter being set did not work. Fix this by adding an empty category to be included.
For convenience, I have also added the -f and -c flags that are accepted by`torrent list`.
