### PR TITLE
fix(config): add Windows home dir path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/domain"
 
@@ -32,19 +34,21 @@ func InitConfig() {
 			os.Exit(1)
 		}
 
-		// Search config in directories
 		viper.SetConfigName(".qbt")
+		// Search config in directories
+		// call multiple times to add many search paths
 		viper.AddConfigPath(".") // optionally look for config in the working directory
 		viper.AddConfigPath(home)
-		viper.AddConfigPath(home + "/.config/qbt")
-		viper.AddConfigPath("$HOME/.config/qbt") // call multiple times to add many search paths
+		viper.AddConfigPath(filepath.Join(home, ".config", "qbt")) // windows path
+		viper.AddConfigPath("$HOME/.config/qbt")
 	}
 
 	if err := viper.ReadInConfig(); err != nil {
-		if ferr, ok := err.(*viper.ConfigFileNotFoundError); ok {
+		var ferr *viper.ConfigFileNotFoundError
+		if errors.As(err, &ferr) {
 			fmt.Printf("config file not found: err %q\n", ferr)
 		} else {
-			fmt.Println("Could not read config file:", err)
+			fmt.Printf("could not read config: err %q\n", err)
 		}
 		os.Exit(1)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ func InitConfig() {
 		viper.SetConfigName(".qbt")
 		viper.AddConfigPath(".") // optionally look for config in the working directory
 		viper.AddConfigPath(home)
+		viper.AddConfigPath(home + "/.config/qbt")
 		viper.AddConfigPath("$HOME/.config/qbt") // call multiple times to add many search paths
 	}
 


### PR DESCRIPTION
On PowerShell / CMD the HOME environment variable is often not defined, so $HOME/.config/qbt will evaluate to C:/.config/qbt instead of C:/\<username\>/.config/qbt as one would expect.