### PR TITLE
feat: validate hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .qbt.toml
 dist
 bin
+testdata

--- a/cmd/torrent_category.go
+++ b/cmd/torrent_category.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
 	"log"
 	"os"
 	"strings"
@@ -54,6 +55,15 @@ func RunTorrentCategorySet() *cobra.Command {
 	command.Flags().StringSliceVar(&hashes, "hashes", []string{}, "Torrent hashes, as comma separated list")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(hashes) == 0 {
+			log.Println("No hashes supplied!")
+		}
+
+		err := utils.ValidateHash(hashes)
+		if err != nil {
+			log.Fatalf("Invalid hashes supplied: %v", err)
+		}
+
 		config.InitConfig()
 
 		qbtSettings := qbittorrent.Config{

--- a/cmd/torrent_list.go
+++ b/cmd/torrent_list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
 	"log"
 	"os"
 	"strings"
@@ -39,6 +40,13 @@ func RunTorrentList() *cobra.Command {
 	command.Flags().StringSliceVar(&hashes, "hashes", []string{}, "Filter by hashes. Separated by comma: \"hash1,hash2\".")
 
 	command.Run = func(cmd *cobra.Command, args []string) {
+		if len(hashes) > 0 {
+			err := utils.ValidateHash(hashes)
+			if err != nil {
+				log.Fatalf("Invalid hashes supplied: %v", err)
+			}
+		}
+
 		config.InitConfig()
 
 		qbtSettings := qbittorrent.Config{

--- a/cmd/torrent_pause.go
+++ b/cmd/torrent_pause.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
 	"log"
 	"os"
 
@@ -30,6 +31,13 @@ func RunTorrentPause() *cobra.Command {
 	command.Flags().BoolVar(&names, "names", false, "Provided arguments will be read as torrent names")
 
 	command.Run = func(cmd *cobra.Command, args []string) {
+		if len(hashes) > 0 {
+			err := utils.ValidateHash(hashes)
+			if err != nil {
+				log.Fatalf("Invalid hashes supplied: %v", err)
+			}
+		}
+
 		config.InitConfig()
 
 		qbtSettings := qbittorrent.Config{
@@ -54,7 +62,7 @@ func RunTorrentPause() *cobra.Command {
 		}
 
 		if len(hashes) == 0 {
-			log.Printf("No torrents found to pause with provided search terms")
+			log.Printf("No torrents found to pause with provided hashes. Use --all to pause all torrents.")
 			return
 		}
 

--- a/cmd/torrent_recheck.go
+++ b/cmd/torrent_recheck.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
 	"log"
 	"os"
 
@@ -34,6 +35,11 @@ func RunTorrentRecheck() *cobra.Command {
 			return
 		}
 
+		err := utils.ValidateHash(hashes)
+		if err != nil {
+			log.Fatalf("Invalid hashes supplied: %v", err)
+		}
+
 		config.InitConfig()
 
 		qbtSettings := qbittorrent.Config{
@@ -53,7 +59,7 @@ func RunTorrentRecheck() *cobra.Command {
 			os.Exit(1)
 		}
 
-		err := batchRequests(hashes, func(start, end int) error {
+		err = batchRequests(hashes, func(start, end int) error {
 			return qb.RecheckCtx(ctx, hashes[start:end])
 		})
 		if err != nil {

--- a/cmd/torrent_remove.go
+++ b/cmd/torrent_remove.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
 	"log"
 	"os"
 
@@ -40,6 +41,13 @@ func RunTorrentRemove() *cobra.Command {
 	command.Flags().StringSliceVar(&excludeTags, "exclude-tags", []string{}, "Exclude torrents with provided tags")
 
 	command.Run = func(cmd *cobra.Command, args []string) {
+		if len(hashes) > 0 {
+			err := utils.ValidateHash(hashes)
+			if err != nil {
+				log.Fatalf("Invalid hashes supplied: %v", err)
+			}
+		}
+
 		config.InitConfig()
 
 		qbtSettings := qbittorrent.Config{

--- a/cmd/torrent_resume.go
+++ b/cmd/torrent_resume.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
 	"log"
 	"os"
 	"time"
@@ -29,6 +30,13 @@ func RunTorrentResume() *cobra.Command {
 	command.Flags().StringSliceVar(&hashes, "hashes", []string{}, "Add hashes as comma separated list")
 
 	command.Run = func(cmd *cobra.Command, args []string) {
+		if len(hashes) > 0 {
+			err := utils.ValidateHash(hashes)
+			if err != nil {
+				log.Fatalf("Invalid hashes supplied: %v", err)
+			}
+		}
+
 		config.InitConfig()
 
 		qbtSettings := qbittorrent.Config{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var hashRegex = regexp.MustCompile("^[a-fA-F0-9]{40}$")
+
+func ValidateHash(hashes []string) error {
+	var invalid []string
+
+	for _, hash := range hashes {
+		if !hashRegex.MatchString(hash) {
+			invalid = append(invalid, hash)
+		}
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid hashes: %s", strings.Join(invalid, ","))
+	}
+
+	return nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import "testing"
+
+func TestValidateHash(t *testing.T) {
+	type args struct {
+		hashes []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{name: "ok", args: args{hashes: []string{"6957bf5272f5b994132458a557864e3ea747489f"}}, want: true, wantErr: false},
+		{name: "invalid", args: args{hashes: []string{"6957bf5272f5b994132458a557864e3ea747489"}}, want: false, wantErr: true},
+		{name: "invalid_2", args: args{hashes: []string{"11111"}}, want: false, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateHash(tt.args.hashes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateHash() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add validation for hashes on various commands. It checks for alpha-numeric strings with a certain length. It does however not validate that the hashes actually exists in the client.

Related #94 