### PR TITLE
fix(export): add missing tracker to .torrent

### DIFF
--- a/cmd/torrent_export.go
+++ b/cmd/torrent_export.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/archive"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
 	"io/fs"
 	"log"
 	"os"
@@ -14,7 +12,9 @@ import (
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
 	fsutil "github.com/ludviglundgren/qbittorrent-cli/internal/fs"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/archive"
 	qbit "github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
+	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/autobrr/go-qbittorrent"

--- a/cmd/torrent_export.go
+++ b/cmd/torrent_export.go
@@ -246,11 +246,15 @@ func exportManifest(hashes map[string]qbittorrent.Torrent, tags map[string]struc
 	}
 	defer manifestFile.Close()
 
-	if err := json.NewEncoder(manifestFile).Encode(&data); err != nil {
+	// create new encoder with pretty print
+	encoder := json.NewEncoder(manifestFile)
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(&data); err != nil {
 		return errors.Wrap(err, "could not encode manifest to json")
 	}
 
-	log.Printf("wrote export manifest to %s", manifestFilePath)
+	log.Printf("wrote export manifest to %s\n", manifestFilePath)
 
 	return nil
 }
@@ -418,7 +422,7 @@ func processExport(sourceDir, exportDir string, hashes map[string]qbittorrent.To
 		return err
 	}
 
-	log.Printf("found (%d) files in total. exported fastresume: %d exported torrent %d", exportFastresumeCount+exportTorrentCount, exportFastresumeCount, exportTorrentCount)
+	log.Printf("exported (%d) files in total: fastresume (%d) torrents (%d)\n", exportFastresumeCount+exportTorrentCount, exportFastresumeCount, exportTorrentCount)
 
 	return nil
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1,0 +1,70 @@
+package archive
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func TarGzDirectory(source, target string) error {
+	file, err := os.Create(target)
+	if err != nil {
+		return fmt.Errorf("failed to create tar.gz file: %w", err)
+	}
+	defer file.Close()
+
+	// Create a new gzip writer
+	gzipWriter := gzip.NewWriter(file)
+	defer gzipWriter.Close()
+
+	// Create a new tar writer
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	err = filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Create a tar header from file info
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+
+		// Preserve the directory structure
+		header.Name, err = filepath.Rel(filepath.Dir(source), path)
+		if err != nil {
+			return err
+		}
+
+		// Write the header to the tar archive
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+
+		// If it's a file, write its content to the tar archive
+		if !info.IsDir() {
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+
+			if _, err := io.Copy(tarWriter, file); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to add files to %s.tar.gz archive: %w", target, err)
+	}
+
+	return nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"os/user"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -22,4 +24,17 @@ func ValidateHash(hashes []string) error {
 	}
 
 	return nil
+}
+
+// ExpandTilde expands the ~ in the file path to the home directory
+func ExpandTilde(path string) (string, error) {
+	if strings.HasPrefix(path, "~") {
+		usr, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		homeDir := usr.HomeDir
+		return filepath.Join(homeDir, path[1:]), nil
+	}
+	return path, nil
 }


### PR DESCRIPTION
Add fix for export on newer qbittorrent versions which removes the `announce` and `announce-urls` fields from the .torrent file.

Needs some extra checks and testing.