### PR TITLE
fix(importer): typos, logging and dry run handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ After the import you will have to manually delete the torrents from the source c
 
 #### Workflow
 
-Torrents imported into qBittorrent does not have automatic management enabled, because it's default behavior is to move data.
+Torrents imported into qBittorrent do not have automatic management enabled, because its default behavior is to move data.
 
 1. Stop source client and qBittorrent.
 2. Start with a dry run and see what it does `qbt torrent import ..... --dry-run`

--- a/cmd/torrent_import.go
+++ b/cmd/torrent_import.go
@@ -34,7 +34,6 @@ func RunTorrentImport() *cobra.Command {
 	}
 
 	var (
-		//source     string
 		sourceDir  string
 		qbitDir    string
 		dryRun     bool
@@ -42,12 +41,10 @@ func RunTorrentImport() *cobra.Command {
 	)
 
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Run without importing anything")
-	//command.Flags().StringVar(&source, "source", "", "source client [deluge, rtorrent] (required)")
 	command.Flags().StringVar(&sourceDir, "source-dir", "", "source client state dir (required)")
 	command.Flags().StringVar(&qbitDir, "qbit-dir", "", "qBittorrent BT_backup dir. Commonly ~/.local/share/qBittorrent/BT_backup (required)")
 	command.Flags().BoolVar(&skipBackup, "skip-backup", false, "Skip backup before import")
 
-	//command.MarkFlagRequired("source")
 	command.MarkFlagRequired("source-dir")
 	command.MarkFlagRequired("qbit-dir")
 

--- a/internal/importer/deluge.go
+++ b/internal/importer/deluge.go
@@ -76,15 +76,11 @@ func (di *DelugeImport) Import(opts Options) error {
 
 		// If a file exist in fastresume data but no .torrent file, skip
 		if _, err = os.Stat(torrentNamePath); os.IsNotExist(err) {
+			log.Printf("%s: skipping because %s not found in source directory\n", torrentID, torrentNamePath)
 			continue
 		}
 
 		positionNum++
-
-		if opts.DryRun {
-			log.Printf("dry-run: (%d/%d) successfully imported: %s\n", positionNum, totalJobs, torrentID)
-			continue
-		}
 
 		torrentOutFile := filepath.Join(opts.QbitDir, torrentID+".torrent")
 
@@ -145,6 +141,11 @@ func (di *DelugeImport) Import(opts Options) error {
 		fastResume.FillPieces()
 
 		// TODO handle replace paths
+
+		if opts.DryRun {
+			log.Printf("dry-run: (%d/%d) successfully imported: %s\n", positionNum, totalJobs, torrentID)
+			continue
+		}
 
 		fastResumeOutFile := filepath.Join(opts.QbitDir, torrentID+".fastresume")
 		if err = fastResume.Encode(fastResumeOutFile); err != nil {


### PR DESCRIPTION
* Fix typos in README.md
* Remove commented-out code from last refactor
* Move handling of --dry-run to later in the import process, so that it calls `continue` just before the first write happens.
* Add logging to error path

Fixes #114 