### PR TITLE
fix(reannounce): fail if hash does not exist

### DIFF
--- a/cmd/torrent_reannounce.go
+++ b/cmd/torrent_reannounce.go
@@ -69,6 +69,9 @@ func RunTorrentReannounce() *cobra.Command {
 		if err != nil {
 			log.Fatalf("could not fetch torrents: err: %q", err)
 		}
+		if hash != "" && len(activeDownloads) != 1 {
+			log.Fatalf("torrent not found: %s", hash)
+		}
 
 		if dry {
 			log.Println("dry-run: torrents successfully re-announced!")


### PR DESCRIPTION
This still allows the use case of not specifying a hash at all and re-announcing all torrents.  I do not know why you would want that, but it was a use case and it still works.

Fixes #116 