### PR TITLE
fix(torrent_add): add 'stopped' option

### DIFF
--- a/cmd/torrent_add.go
+++ b/cmd/torrent_add.go
@@ -102,6 +102,7 @@ func RunTorrentAdd() *cobra.Command {
 		options := map[string]string{}
 		if paused {
 			options["paused"] = "true"
+			options["stopped"] = "true"
 		}
 		if skipHashCheck {
 			options["skip_checking"] = "true"


### PR DESCRIPTION
Fixes the issue where torrents added with the `--paused` flag were not added in a paused state as expected on v5+