### PR TITLE
feat(cli): silence usage with -q and --quiet

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -2,12 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -53,18 +52,17 @@ func RunAppVersion() *cobra.Command {
 		ctx := cmd.Context()
 
 		if err := qb.LoginCtx(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "could not login to qbit: %q\n", err)
-			os.Exit(1)
+			return errors.Wrap(err, "could not login to qbit")
 		}
 
 		appVersion, err := qb.GetAppVersionCtx(ctx)
 		if err != nil {
-			log.Fatal("could not get app version")
+			return errors.Wrap(err, "could not get app version")
 		}
 
 		webapiVersion, err := qb.GetWebAPIVersionCtx(ctx)
 		if err != nil {
-			log.Fatal("could not get web api version")
+			return errors.Wrap(err, "could not get web api version")
 		}
 
 		switch output {

--- a/cmd/category.go
+++ b/cmd/category.go
@@ -60,17 +60,16 @@ func RunCategoryList() *cobra.Command {
 		ctx := cmd.Context()
 
 		if err := qb.LoginCtx(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "could not login to qbit: %q\n", err)
-			os.Exit(1)
+			return errors.Wrap(err, "could not login to qbit")
 		}
 
 		cats, err := qb.GetCategoriesCtx(ctx)
 		if err != nil {
-			log.Fatal("could not get categories")
+			return errors.Wrap(err, "could not get categories")
 		}
 
 		if len(cats) == 0 {
-			fmt.Println("No categories found")
+			log.Println("No categories found")
 			return nil
 		}
 
@@ -78,14 +77,15 @@ func RunCategoryList() *cobra.Command {
 		case "json":
 			res, err := json.Marshal(cats)
 			if err != nil {
-				log.Fatalf("could not marshal categories, err: %q", err)
+				return errors.Wrap(err, "could not marshal categories")
 			}
 
 			fmt.Println(string(res))
 
 		default:
-			printCategoryList(cats)
-
+			if err := printCategoryList(cats); err != nil {
+				return errors.Wrap(err, "could not print category list")
+			}
 		}
 
 		return nil
@@ -100,16 +100,18 @@ Save path: {{.SavePath}}
 {{end}}
 `
 
-func printCategoryList(categories map[string]qbittorrent.Category) {
+func printCategoryList(categories map[string]qbittorrent.Category) error {
 	tmpl, err := template.New("category-list").Parse(categoryItemTemplate)
 	if err != nil {
-		log.Fatalf("error: %q", err)
+		return err
 	}
 
 	err = tmpl.Execute(os.Stdout, categories)
 	if err != nil {
-		log.Fatalf("could not generate template: %q", err)
+		return errors.Wrap(err, "could not generate template")
 	}
+
+	return nil
 }
 
 // RunCategoryAdd cmd to add categories
@@ -152,8 +154,7 @@ func RunCategoryAdd() *cobra.Command {
 		ctx := cmd.Context()
 
 		if err := qb.LoginCtx(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "could not login to qbit: %q\n", err)
-			os.Exit(1)
+			return errors.Wrap(err, "could not login to qbit")
 		}
 
 		// args
@@ -167,7 +168,7 @@ func RunCategoryAdd() *cobra.Command {
 
 		} else {
 			if err := qb.CreateCategoryCtx(ctx, category, savePath); err != nil {
-				log.Fatal("could not create category")
+				return errors.Wrap(err, "could not create category")
 			}
 
 			log.Printf("successfully added category: %s\n", category)
@@ -216,8 +217,7 @@ func RunCategoryDelete() *cobra.Command {
 		ctx := cmd.Context()
 
 		if err := qb.LoginCtx(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "could not login to qbit: %q\n", err)
-			os.Exit(1)
+			return errors.Wrap(err, "could not login to qbit")
 		}
 
 		// args
@@ -231,7 +231,7 @@ func RunCategoryDelete() *cobra.Command {
 
 		} else {
 			if err := qb.RemoveCategoriesCtx(ctx, []string{category}); err != nil {
-				log.Fatal("could not delete category")
+				return errors.Wrap(err, "could not delete category")
 			}
 
 			log.Printf("successfully deleted category: %s\n", category)
@@ -283,8 +283,7 @@ func RunCategoryEdit() *cobra.Command {
 		ctx := cmd.Context()
 
 		if err := qb.LoginCtx(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "could not login to qbit: %q\n", err)
-			os.Exit(1)
+			return errors.Wrap(err, "could not login to qbit")
 		}
 
 		// args
@@ -298,7 +297,7 @@ func RunCategoryEdit() *cobra.Command {
 
 		} else {
 			if err := qb.EditCategoryCtx(ctx, category, savePath); err != nil {
-				log.Fatal("could not edit category")
+				return errors.Wrap(err, "could not edit category")
 			}
 
 			log.Printf("successfully edited category: %s\n", category)

--- a/cmd/qbt/main.go
+++ b/cmd/qbt/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"log"
 	"os"
 
@@ -18,6 +19,8 @@ var (
 
 func main() {
 
+	var silentOutput bool
+
 	log.SetFlags(0)
 
 	var rootCmd = &cobra.Command{
@@ -26,10 +29,18 @@ func main() {
 		Long: `Manage qBittorrent from command line.
 
 Documentation is available at https://github.com/ludviglundgren/qbittorrent-cli`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if silentOutput {
+				log.SetOutput(io.Discard)
+				// Uncomment to also suppress standard output
+				// os.Stdout = io.Discard
+			}
+		},
 	}
 
 	// override config
 	rootCmd.PersistentFlags().StringVar(&config.CfgFile, "config", "", "config file (default is $HOME/.config/qbt/.qbt.toml)")
+	rootCmd.PersistentFlags().BoolVarP(&silentOutput, "quiet", "q", false, "suppress output")
 
 	rootCmd.AddCommand(cmd.RunApp())
 	rootCmd.AddCommand(cmd.RunBencode())

--- a/cmd/torrent_add.go
+++ b/cmd/torrent_add.go
@@ -201,7 +201,7 @@ func RunTorrentAdd() *cobra.Command {
 
 				defer response.Body.Close()
 
-				if response.StatusCode != http.StatusOK || response.StatusCode != http.StatusCreated || response.StatusCode != http.StatusNoContent {
+				if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusNoContent {
 					return errors.Errorf("unexpected status: %d", response.StatusCode)
 				}
 

--- a/cmd/torrent_export.go
+++ b/cmd/torrent_export.go
@@ -528,7 +528,7 @@ func containsTag(contains []string, tags []string) bool {
 
 func containsCategory(contains []string, category string) bool {
 	for _, cat := range contains {
-		if strings.ToLower(category) == strings.ToLower(cat) {
+		if strings.EqualFold(category, cat) {
 			return true
 		}
 	}

--- a/cmd/torrent_hash.go
+++ b/cmd/torrent_hash.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/anacrolix/torrent/metainfo"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -25,14 +24,14 @@ func RunTorrentHash() *cobra.Command {
 		},
 	}
 
-	command.Run = func(cmd *cobra.Command, args []string) {
+	command.RunE = func(cmd *cobra.Command, args []string) error {
 		filePath := args[0]
 		hash := ""
 
 		if strings.HasPrefix(filePath, "magnet:") {
 			metadata, err := metainfo.ParseMagnetUri(filePath)
 			if err != nil {
-				log.Fatalf("could not parse magnet URI. error: %v", err)
+				return errors.Wrapf(err, "could not parse magnet URI: %s", filePath)
 			}
 
 			hash = metadata.InfoHash.HexString()
@@ -40,13 +39,16 @@ func RunTorrentHash() *cobra.Command {
 		} else {
 			metadata, err := metainfo.LoadFromFile(filePath)
 			if err != nil {
-				log.Fatalf("could not parse torrent file. error: %v", err)
+				return errors.Wrapf(err, "could not parse torrent file: %s", filePath)
 			}
 
 			hash = metadata.HashInfoBytes().HexString()
 		}
 
 		fmt.Println(hash)
+
+		return nil
 	}
+
 	return command
 }

--- a/cmd/torrent_tracker.go
+++ b/cmd/torrent_tracker.go
@@ -1,14 +1,13 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -63,13 +62,12 @@ func RunTorrentTrackerEdit() *cobra.Command {
 		ctx := cmd.Context()
 
 		if err := qb.LoginCtx(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "could not login to qbit: %q\n", err)
-			os.Exit(1)
+			return errors.Wrap(err, "could not login to qbit")
 		}
 
 		torrents, err := qb.GetTorrentsCtx(ctx, qbittorrent.TorrentFilterOptions{})
 		if err != nil {
-			log.Fatalf("could not get torrents err: %q\n", err)
+			errors.Wrap(err, "could not get torrents")
 		}
 
 		var torrentsToUpdate []qbittorrent.Torrent
@@ -93,7 +91,7 @@ func RunTorrentTrackerEdit() *cobra.Command {
 				log.Printf("[%d/%d] updating tracker for torrent %s %q\n", i+1, len(torrentsToUpdate), torrent.Hash, torrent.Name)
 
 				if err := qb.EditTrackerCtx(ctx, torrent.Hash, torrent.Tracker, newURL); err != nil {
-					log.Fatalf("could not edit tracker for torrent: %s\n", torrent.Hash)
+					return errors.Wrapf(err, "could not edit tracker for torrent: %s", torrent.Hash)
 				}
 			}
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/blang/semver"
+	"github.com/pkg/errors"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"
 	"github.com/spf13/cobra"
 )
@@ -20,17 +21,15 @@ func RunUpdate(version string) *cobra.Command {
 
 	command.Flags().BoolVar(&verbose, "verbose", false, "Verbose output: Print changelog")
 
-	command.Run = func(cmd *cobra.Command, args []string) {
+	command.RunE = func(cmd *cobra.Command, args []string) error {
 		v, err := semver.ParseTolerant(version)
 		if err != nil {
-			log.Println("could not parse version:", err)
-			return
+			return errors.Wrapf(err, "could not parse version string: %s", version)
 		}
 
 		latest, err := selfupdate.UpdateSelf(v, "ludviglundgren/qbittorrent-cli")
 		if err != nil {
-			log.Println("Binary update failed:", err)
-			return
+			return errors.Wrap(err, "binary update failed")
 		}
 
 		if latest.Version.Equals(v) {
@@ -44,7 +43,7 @@ func RunUpdate(version string) *cobra.Command {
 			}
 		}
 
-		return
+		return nil
 	}
 
 	return command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +20,7 @@ func RunVersion(version, commit, date string) *cobra.Command {
 
 	command.Flags().StringVar(&output, "output", "text", "Print as [text, json]")
 
-	command.Run = func(cmd *cobra.Command, args []string) {
+	command.RunE = func(cmd *cobra.Command, args []string) error {
 		switch output {
 		case "text":
 			fmt.Printf(`qbt - qbitttorrent cli
@@ -28,17 +28,19 @@ Version: %s
 Commit: %s
 Date: %s
 `, version, commit, date)
-			return
+			return nil
 
 		case "json":
 			res, err := json.Marshal(versionInfo{Version: version, Commit: commit, Date: date})
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "ERROR: could not marshal version info to json %v\n", err)
-				os.Exit(1)
+
+				return errors.Wrap(err, "could not marshal version info to json")
 			}
 			fmt.Println(string(res))
 
 		}
+
+		return nil
 	}
 
 	return command

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"errors"
-	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -30,8 +30,7 @@ func InitConfig() {
 		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
-			fmt.Println("Could not read home dir:", err)
-			os.Exit(1)
+			log.Fatal("could not read home dir: %w", err)
 		}
 
 		viper.SetConfigName(".qbt")
@@ -46,9 +45,9 @@ func InitConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		var ferr *viper.ConfigFileNotFoundError
 		if errors.As(err, &ferr) {
-			fmt.Printf("config file not found: err %q\n", ferr)
+			log.Printf("config file not found: err %q\n", ferr)
 		} else {
-			fmt.Printf("could not read config: err %q\n", err)
+			log.Printf("could not read config: err %q\n", err)
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
Silence output with global flag `-q` or `--quiet`. Errors are still printed to stderr.

Closes #107 