### PR TITLE
fix(add): include savepath for magnets

### DIFF
--- a/cmd/torrent_add.go
+++ b/cmd/torrent_add.go
@@ -120,7 +120,7 @@ func RunTorrentAdd() *cobra.Command {
 			options["skip_checking"] = "true"
 		}
 		if savePath != "" {
-			// options["savepath"] = savePath
+			options["savepath"] = savePath
 			options["autoTMM"] = "false"
 		}
 		if category != "" {


### PR DESCRIPTION
--save-path arguments doesn't work when adding magnets