### PR TITLE
feat(torrent-add): add sequential and first/last piece defaults

### DIFF
--- a/.qbt.toml.example
+++ b/.qbt.toml.example
@@ -28,3 +28,9 @@ login      = "user"
 password   = "password"
 #basicUser = "user"
 #basicPass = "password"
+
+[add]
+# download pieces in sequential order by default, useful for video streaming
+sequential = false
+# prioritize first and last pieces for all new torrents
+first_last_piece = false

--- a/cmd/torrent_add.go
+++ b/cmd/torrent_add.go
@@ -32,19 +32,21 @@ const (
 // RunTorrentAdd cmd to add torrents
 func RunTorrentAdd() *cobra.Command {
 	var (
-		dry           bool
-		paused        bool
-		skipHashCheck bool
-		removeStalled bool
-		savePath      string
-		category      string
-		tags          []string
-		ignoreRules   bool
-		uploadLimit   uint64
-		downloadLimit uint64
-		stopCondition string
-		sleep         time.Duration
-		recheck       bool
+		dry            bool
+		paused         bool
+		skipHashCheck  bool
+		sequential     bool
+		firstLastPiece bool
+		removeStalled  bool
+		savePath       string
+		category       string
+		tags           []string
+		ignoreRules    bool
+		uploadLimit    uint64
+		downloadLimit  uint64
+		stopCondition  string
+		sleep          time.Duration
+		recheck        bool
 	)
 
 	command := &cobra.Command{
@@ -66,6 +68,8 @@ func RunTorrentAdd() *cobra.Command {
 	command.Flags().BoolVar(&dry, "dry-run", false, "Run without doing anything")
 	command.Flags().BoolVar(&paused, "paused", false, "Add torrent in paused state")
 	command.Flags().BoolVar(&skipHashCheck, "skip-hash-check", false, "Skip hash check")
+	command.Flags().BoolVar(&sequential, "sequential", false, "Download torrent pieces in sequential order")
+	command.Flags().BoolVar(&firstLastPiece, "first-last-piece", false, "Prioritize first and last pieces for preview")
 	command.Flags().BoolVar(&ignoreRules, "ignore-rules", false, "Ignore rules from config")
 	command.Flags().BoolVar(&removeStalled, "remove-stalled", false, "Remove stalled torrents from re-announce")
 	command.Flags().StringVar(&savePath, "save-path", "", "Add torrent to the specified path")
@@ -118,6 +122,20 @@ func RunTorrentAdd() *cobra.Command {
 		}
 		if skipHashCheck {
 			options["skip_checking"] = "true"
+		}
+		if command.Flags().Changed("sequential") {
+			if sequential {
+				options["sequentialDownload"] = "true"
+			}
+		} else if config.Add.Sequential {
+			options["sequentialDownload"] = "true"
+		}
+		if command.Flags().Changed("first-last-piece") {
+			if firstLastPiece {
+				options["firstLastPiecePrio"] = "true"
+			}
+		} else if config.Add.FirstLastPiece {
+			options["firstLastPiecePrio"] = "true"
 		}
 		if savePath != "" {
 			// options["savepath"] = savePath

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ var (
 	Compare    []domain.QbitConfig
 	Reannounce domain.ReannounceSettings
 	Rules      domain.Rules
+	Add        domain.AddConfig
 )
 
 // InitConfig initialize config
@@ -60,4 +61,5 @@ func InitConfig() {
 	Compare = Config.Compare
 	Reannounce = Config.Reannounce
 	Rules = Config.Rules
+	Add = Config.Add
 }

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -21,10 +21,16 @@ type Rules struct {
 	MaxActiveDownloads int  `mapstructure:"max_active_downloads"`
 }
 
+type AddConfig struct {
+	Sequential     bool `mapstructure:"sequential"`
+	FirstLastPiece bool `mapstructure:"first_last_piece"`
+}
+
 type AppConfig struct {
 	Debug      bool               `mapstructure:"debug"`
 	Qbit       QbitConfig         `mapstructure:"qbittorrent"`
 	Reannounce ReannounceSettings `mapstructure:"reannounce"`
 	Rules      Rules              `mapstructure:"rules"`
+	Add        AddConfig          `mapstructure:"add"`
 	Compare    []QbitConfig       `mapstructure:"compare"`
 }


### PR DESCRIPTION
Adds `--sequential` and `--first-last-piece` to `qbt torrent add`.

Also adds optional `[add]` config defaults for both flags, so file and magnet adds can enable `sequentialDownload` and `firstLastPiecePrio` without passing the flags every time.

Example:

```toml
[add]
sequential = true
first_last_piece = true
```

```text
qbt torrent add some.torrent
qbt torrent add --sequential --first-last-piece magnet:?...
```
