### PR TITLE
Allowing login to check for the new 204 http code in addition to 200

### DIFF
--- a/pkg/qbittorrent/methods.go
+++ b/pkg/qbittorrent/methods.go
@@ -23,7 +23,7 @@ func (c *Client) Login(ctx context.Context) error {
 		return errors.Wrap(err, "login error")
 	}
 
-	if resp.StatusCode != http.StatusOK { // check for correct status code
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent { // check for correct status code
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err


### PR DESCRIPTION
QBittorrent 5.2+ return (accurately) a 204, rather than a 200 on login when returning no data with the response. Since qbt was just checking for http.StatusOk (200), it throws an error on this successful login. This PR just lets it check for StatusOk and StatusNoContent. Ezpz.

Tested working on my qbittorrent 5.2.2 install.