### PR TITLE
feat(auth): add API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ A bare minimum config. Check [full example config](.qbt.toml.example).
 ```toml
 [qbittorrent]
 addr       = "http://127.0.0.1:6776" # qbittorrent webui-api hostname/ip
-login      = "user"                  # qbittorrent webui-api user
-password   = "password"              # qbittorrent webui-api password
-#basicUser = "user"                  # qbittorrent webui-api basic auth user
-#basicPass = "password"              # qbittorrent webui-api basic auth password
+apikey     = "APIKEY"                # qbittorrent webui-api api key ONLY qbit 5.2.x+ (OPTIONAL)
+login      = "user"                  # qbittorrent webui-api user                     (OPTIONAL)
+password   = "password"              # qbittorrent webui-api password                 (OPTIONAL)
+#basicUser = "user"                  # qbittorrent webui-api basic auth user          (OPTIONAL)
+#basicPass = "password"              # qbittorrent webui-api basic auth password      (OPTIONAL)
 
 [rules]
 enabled              = true   # enable or disable rules

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -41,6 +41,7 @@ func RunAppVersion() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/category.go
+++ b/cmd/category.go
@@ -49,6 +49,7 @@ func RunCategoryList() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,
@@ -143,6 +144,7 @@ func RunCategoryAdd() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,
@@ -206,6 +208,7 @@ func RunCategoryDelete() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,
@@ -272,6 +275,7 @@ func RunCategoryEdit() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -48,6 +48,7 @@ func RunTagList() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,
@@ -138,6 +139,7 @@ func RunTagAdd() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,
@@ -200,6 +202,7 @@ func RunTagDelete() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_add.go
+++ b/cmd/torrent_add.go
@@ -89,6 +89,7 @@ func RunTorrentAdd() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_category.go
+++ b/cmd/torrent_category.go
@@ -66,6 +66,7 @@ func RunTorrentCategorySet() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,
@@ -125,6 +126,7 @@ func RunTorrentCategoryUnSet() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,
@@ -191,6 +193,7 @@ func RunTorrentCategoryChange() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_compare.go
+++ b/cmd/torrent_compare.go
@@ -20,12 +20,14 @@ func RunTorrentCompare() *cobra.Command {
 		tag           string
 
 		sourceAddr      string
+		sourceAPIKey    string
 		sourceUser      string
 		sourcePass      string
 		sourceBasicUser string
 		sourceBasicPass string
 
 		compareAddr      string
+		compareAPIKey    string
 		compareUser      string
 		comparePass      string
 		compareBasicUser string
@@ -50,12 +52,14 @@ func RunTorrentCompare() *cobra.Command {
 	command.Flags().StringVar(&tag, "tag", "compare-dupe", "set a custom tag for duplicates on compare. default: compare-dupe")
 
 	command.Flags().StringVar(&sourceAddr, "host", "", "Source host")
+	command.Flags().StringVar(&compareAPIKey, "api-key", "", "Source api key")
 	command.Flags().StringVar(&sourceUser, "user", "", "Source user")
 	command.Flags().StringVar(&sourcePass, "pass", "", "Source pass")
 	command.Flags().StringVar(&sourceBasicUser, "basic-user", "", "Source basic auth user")
 	command.Flags().StringVar(&sourceBasicPass, "basic-pass", "", "Source basic auth pass")
 
 	command.Flags().StringVar(&compareAddr, "compare-host", "", "Secondary host")
+	command.Flags().StringVar(&compareAPIKey, "compare-api-key", "", "Secondary api key")
 	command.Flags().StringVar(&compareUser, "compare-user", "", "Secondary user")
 	command.Flags().StringVar(&comparePass, "compare-pass", "", "Secondary pass")
 	command.Flags().StringVar(&compareBasicUser, "compare-basic-user", "", "Secondary basic auth user")
@@ -66,6 +70,9 @@ func RunTorrentCompare() *cobra.Command {
 
 		if sourceAddr == "" {
 			sourceAddr = config.Qbit.Host
+		}
+		if sourceAPIKey == "" {
+			sourceAPIKey = config.Qbit.APIKey
 		}
 		if sourceUser == "" {
 			sourceUser = config.Qbit.Login
@@ -82,6 +89,7 @@ func RunTorrentCompare() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      sourceAddr,
+			APIKey:    sourceAPIKey,
 			Username:  sourceUser,
 			Password:  sourcePass,
 			BasicUser: sourceBasicUser,
@@ -105,6 +113,7 @@ func RunTorrentCompare() *cobra.Command {
 		// Start comparison
 		for _, compareConfig := range config.Compare {
 			compareAddr := compareConfig.Addr
+			compareAPIKey := compareConfig.APIKey
 			compareUser := compareConfig.Login
 			comparePass := compareConfig.Password
 			compareBasicUser := compareConfig.BasicUser
@@ -112,6 +121,7 @@ func RunTorrentCompare() *cobra.Command {
 
 			qbtSettingsCompare := qbittorrent.Config{
 				Host:      compareAddr,
+				APIKey:    compareAPIKey,
 				Username:  compareUser,
 				Password:  comparePass,
 				BasicUser: compareBasicUser,

--- a/cmd/torrent_export.go
+++ b/cmd/torrent_export.go
@@ -95,6 +95,7 @@ func RunTorrentExport() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_list.go
+++ b/cmd/torrent_list.go
@@ -51,6 +51,7 @@ func RunTorrentList() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_pause.go
+++ b/cmd/torrent_pause.go
@@ -39,6 +39,7 @@ func RunTorrentPause() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_reannounce.go
+++ b/cmd/torrent_reannounce.go
@@ -41,6 +41,7 @@ func RunTorrentReannounce() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_recheck.go
+++ b/cmd/torrent_recheck.go
@@ -42,6 +42,7 @@ func RunTorrentRecheck() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_remove.go
+++ b/cmd/torrent_remove.go
@@ -50,6 +50,7 @@ func RunTorrentRemove() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_resume.go
+++ b/cmd/torrent_resume.go
@@ -39,6 +39,7 @@ func RunTorrentResume() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_tag.go
+++ b/cmd/torrent_tag.go
@@ -132,6 +132,7 @@ func RunTorrentTagNotWorking() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/cmd/torrent_tracker.go
+++ b/cmd/torrent_tracker.go
@@ -51,6 +51,7 @@ func RunTorrentTrackerEdit() *cobra.Command {
 
 		qbtSettings := qbittorrent.Config{
 			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
 			Username:  config.Qbit.Login,
 			Password:  config.Qbit.Password,
 			BasicUser: config.Qbit.BasicUser,

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -6,6 +6,7 @@ type QbitConfig struct {
 	Port      uint   `mapstructure:"port"`
 	Login     string `mapstructure:"login"`
 	Password  string `mapstructure:"password"`
+	APIKey    string `mapstructure:"apikey"`
 	BasicUser string `mapstructure:"basicUser"`
 	BasicPass string `mapstructure:"basicPass"`
 }


### PR DESCRIPTION
Add API key support for newer qbit 5.2.x versions.

Resolves #154 