### PR TITLE
feat: show transfer info

### DIFF
--- a/cmd/qbt/main.go
+++ b/cmd/qbt/main.go
@@ -45,6 +45,7 @@ Documentation is available at https://github.com/ludviglundgren/qbittorrent-cli`
 	rootCmd.AddCommand(cmd.RunApp())
 	rootCmd.AddCommand(cmd.RunBencode())
 	rootCmd.AddCommand(cmd.RunTorrent())
+	rootCmd.AddCommand(cmd.RunTransfer())
 	rootCmd.AddCommand(cmd.RunCategory())
 	rootCmd.AddCommand(cmd.RunTag())
 	rootCmd.AddCommand(cmd.RunVersion(version, commit, date))

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+
+	"github.com/autobrr/go-qbittorrent"
+	"github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// RunTransfer cmd for transfer info
+func RunTransfer() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "transfer",
+		Short: "Transfer info subcommand",
+		Long:  "Get status and speed info",
+	}
+
+	command.AddCommand(RunAppVersion())
+
+	return command
+}
+
+// RunAppVersion cmd to view application info
+func RunTransferInfo() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "info",
+		Short: "Get qBittorrent transfer info",
+	}
+
+	var (
+		output string
+	)
+
+	command.Flags().StringVar(&output, "output", "", "Print as [formatted text (default), json]")
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		config.InitConfig()
+
+		qbtSettings := qbittorrent.Config{
+			Host:      config.Qbit.Addr,
+			APIKey:    config.Qbit.APIKey,
+			Username:  config.Qbit.Login,
+			Password:  config.Qbit.Password,
+			BasicUser: config.Qbit.BasicUser,
+			BasicPass: config.Qbit.BasicPass,
+		}
+
+		qb := qbittorrent.NewClient(qbtSettings)
+
+		ctx := cmd.Context()
+
+		if err := qb.LoginCtx(ctx); err != nil {
+			return errors.Wrap(err, "could not login to qbit")
+		}
+
+		info, err := qb.GetTransferInfo()
+		if err != nil {
+			return errors.Wrap(err, "could not get app version")
+		}
+
+		switch output {
+		case "json":
+			res, err := json.Marshal(info)
+			if err != nil {
+				return errors.Wrap(err, "could not marshal transfer info")
+			}
+
+			fmt.Println(string(res))
+
+		default:
+			fmt.Printf("qBittorrent transfer info:\nConnection status: %s\nSession upload: %s\n\nSession download: %s\n", info.ConnectionStatus, humanize.Bytes(uint64(info.UpInfoData)), humanize.Bytes(uint64(info.DlInfoData)))
+		}
+
+		return nil
+	}
+
+	return command
+}

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -25,7 +25,7 @@ func RunTransfer() *cobra.Command {
 	return command
 }
 
-// RunAppVersion cmd to view application info
+// RunTransferInfo cmd to view transfer info
 func RunTransferInfo() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "info",


### PR DESCRIPTION
Add transfer info subcommand `qbt transfer info` which outputs connection status and session upload/download. With `--output=json` it outputs the full json response from qbit.

Resolves #152 