### PR TITLE
fix(export): improve error handling

### DIFF
--- a/cmd/torrent_export.go
+++ b/cmd/torrent_export.go
@@ -298,6 +298,7 @@ func exportManifest(hashes map[string]qbittorrent.Torrent, tags map[string]struc
 func processExport(sourceDir, exportDir string, hashes map[string]qbittorrent.Torrent, dry, verbose bool) error {
 	exportTorrentCount := 0
 	exportFastresumeCount := 0
+	failedCount := 0
 
 	// check if export dir exists, if not then lets create it
 	if err := createDirIfNotExists(exportDir); err != nil {
@@ -309,6 +310,129 @@ func processExport(sourceDir, exportDir string, hashes map[string]qbittorrent.To
 
 	// keep track of processed fastresume files
 	processedFastResumeHashes := map[string]bool{}
+
+	// exportTorrent processes a single matched .torrent file (and its .fastresume).
+	// Any error it returns only concerns this torrent: the caller logs it and moves
+	// on to the remaining files so a single problematic file can't abort the whole
+	// export (see https://github.com/ludviglundgren/qbittorrent-cli/issues/135).
+	exportTorrent := func(dirPath, fileName, torrentHash string, torrent qbittorrent.Torrent) error {
+		outFile := filepath.Join(exportDir, fileName)
+
+		// determine if this should be run on first run and the ones after
+		if (exportTorrentCount == 0 && !needTrackerFix) || needTrackerFix {
+
+			// open file and check if announce is in there. If it's not, open .fastresume and combine before output
+			torrentFile, err := os.Open(dirPath)
+			if err != nil {
+				return errors.Wrapf(err, "could not open torrent file: %s", dirPath)
+			}
+			defer torrentFile.Close()
+
+			torrentInfo, err := metainfo.Load(torrentFile)
+			if err != nil {
+				return errors.Wrapf(err, "could not open file: %s", dirPath)
+			}
+
+			wroteFastResume := false
+
+			if torrentInfo.Announce == "" {
+				needTrackerFix = true
+
+				sourceFastResumeFilePath := filepath.Join(sourceDir, torrentHash+".fastresume")
+				fastResumeFile, err := os.Open(sourceFastResumeFilePath)
+				if err != nil {
+					return errors.Wrapf(err, "could not open fastresume file: %s", sourceFastResumeFilePath)
+				}
+				defer fastResumeFile.Close()
+
+				// open fastresume and get announce
+				var fastResume qbit.Fastresume
+				if err := bencode.NewDecoder(fastResumeFile).Decode(&fastResume); err != nil {
+					return errors.Wrapf(err, "could not decode fastresume file: %s", sourceFastResumeFilePath)
+				}
+
+				if len(fastResume.Trackers) == 0 {
+					return errors.New("no trackers found in fastresume")
+				}
+
+				torrentInfo.Announce = fastResume.Trackers[0][0]
+				torrentInfo.AnnounceList = metainfo.AnnounceList(fastResume.Trackers)
+
+				if len(torrentInfo.UrlList) == 0 && len(fastResume.UrlList) > 0 {
+					torrentInfo.UrlList = fastResume.UrlList
+				}
+
+				// copy .fastresume here already since we already have it open
+				fastresumeFilePath := filepath.Join(exportDir, torrentHash+".fastresume")
+				newFastResumeFile, err := os.Create(fastresumeFilePath)
+				if err != nil {
+					return errors.Wrapf(err, "could not create new fastresume file: %s", fastresumeFilePath)
+				}
+				defer newFastResumeFile.Close()
+
+				if err := bencode.NewEncoder(newFastResumeFile).Encode(&fastResume); err != nil {
+					return errors.Wrapf(err, "could not encode fastresume to file: %s", fastresumeFilePath)
+				}
+
+				wroteFastResume = true
+			}
+
+			// write new torrent file to destination path
+			newTorrentFile, err := os.Create(outFile)
+			if err != nil {
+				return errors.Wrapf(err, "could not create new torrent file: %s", outFile)
+			}
+			defer newTorrentFile.Close()
+
+			if err := torrentInfo.Write(newTorrentFile); err != nil {
+				return errors.Wrapf(err, "could not write torrent info into file %s", outFile)
+			}
+
+			// torrent (and the rebuilt fastresume, if any) written successfully; only
+			// now commit the counters so a partial failure can't inflate the totals
+			if wroteFastResume {
+				// make sure the fastresume is only written once
+				processedFastResumeHashes[torrentHash] = true
+
+				exportFastresumeCount++
+				log.Printf("[%d/%d] exported: %s %s\n", exportFastresumeCount, len(hashes), torrentHash+".fastresume", torrent.Name)
+			}
+
+			exportTorrentCount++
+			log.Printf("[%d/%d] exported: %s    %s\n", exportTorrentCount, len(hashes), fileName, torrent.Name)
+
+			return nil
+		}
+
+		// only do this if !needTrackerFix
+		if err := fsutil.CopyFile(dirPath, outFile); err != nil {
+			return errors.Wrapf(err, "could not copy file: %s to %s", dirPath, outFile)
+		}
+
+		// process if fastresume has not already been copied
+		wroteFastResume := false
+		if _, done := processedFastResumeHashes[torrentHash]; !done {
+			sourceFastResumeFilePath := filepath.Join(sourceDir, torrentHash+".fastresume")
+			fastResumeFilePath := filepath.Join(exportDir, torrentHash+".fastresume")
+
+			if err := fsutil.CopyFile(sourceFastResumeFilePath, fastResumeFilePath); err != nil {
+				return errors.Wrapf(err, "could not copy file: %s to %s", sourceFastResumeFilePath, fastResumeFilePath)
+			}
+
+			wroteFastResume = true
+		}
+
+		// torrent (and fastresume) copied successfully; only now commit the counters
+		exportTorrentCount++
+		log.Printf("[%d/%d] exported: %s    %s\n", exportTorrentCount, len(hashes), fileName, torrent.Name)
+
+		if wroteFastResume {
+			exportFastresumeCount++
+			log.Printf("[%d/%d] exported: %s %s\n", exportFastresumeCount, len(hashes), torrentHash+".fastresume", torrent.Name)
+		}
+
+		return nil
+	}
 
 	// check BT_backup dir, pick torrent and fastresume files by hash
 	err := filepath.WalkDir(sourceDir, func(dirPath string, d fs.DirEntry, err error) error {
@@ -349,106 +473,16 @@ func processExport(sourceDir, exportDir string, hashes map[string]qbittorrent.To
 			return nil
 		}
 
-		outFile := filepath.Join(exportDir, fileName)
+		// process the torrent; on failure log it and continue with the next file
+		// instead of aborting the entire export
+		if err := exportTorrent(dirPath, fileName, torrentHash, torrent); err != nil {
+			failedCount++
+			log.Printf("skipping %s: %v\n", fileName, err)
 
-		// determine if this should be run on first run and the ones after
-		if (exportTorrentCount == 0 && !needTrackerFix) || needTrackerFix {
-
-			// open file and check if announce is in there. If it's not, open .fastresume and combine before output
-			torrentFile, err := os.Open(dirPath)
-			if err != nil {
-				return errors.Wrapf(err, "could not open torrent file: %s", dirPath)
-			}
-			defer torrentFile.Close()
-
-			torrentInfo, err := metainfo.Load(torrentFile)
-			if err != nil {
-				return errors.Wrapf(err, "could not open file: %s", dirPath)
-			}
-
-			if torrentInfo.Announce == "" {
-				needTrackerFix = true
-
-				sourceFastResumeFilePath := filepath.Join(sourceDir, torrentHash+".fastresume")
-				fastResumeFile, err := os.Open(sourceFastResumeFilePath)
-				if err != nil {
-					return errors.Wrapf(err, "could not open fastresume file: %s", sourceFastResumeFilePath)
-				}
-				defer fastResumeFile.Close()
-
-				// open fastresume and get announce then // open fastresume and get announce then <INSERT_CODE_HERE>
-				var fastResume qbit.Fastresume
-				if err := bencode.NewDecoder(fastResumeFile).Decode(&fastResume); err != nil {
-					return errors.Wrapf(err, "could not open file: %s", sourceFastResumeFilePath)
-				}
-
-				if len(fastResume.Trackers) == 0 {
-					return errors.New("no trackers found in fastresume")
-				}
-
-				torrentInfo.Announce = fastResume.Trackers[0][0]
-				torrentInfo.AnnounceList = fastResume.Trackers
-
-				if len(torrentInfo.UrlList) == 0 && len(fastResume.UrlList) > 0 {
-					torrentInfo.UrlList = fastResume.UrlList
-				}
-
-				// copy .fastresume here already since we already have it open
-				fastresumeFilePath := filepath.Join(exportDir, torrentHash+".fastresume")
-				newFastResumeFile, err := os.Create(fastresumeFilePath)
-				if err != nil {
-					return errors.Wrapf(err, "could not create new fastresume file: %s", fastresumeFilePath)
-				}
-				defer newFastResumeFile.Close()
-
-				if err := bencode.NewEncoder(newFastResumeFile).Encode(&fastResume); err != nil {
-					return errors.Wrapf(err, "could not encode fastresume to file: %s", fastresumeFilePath)
-				}
-
-				// make sure the fastresume is only written once
-				processedFastResumeHashes[torrentHash] = true
-
-				exportFastresumeCount++
-				log.Printf("[%d/%d] exported: %s %s\n", exportFastresumeCount, len(hashes), torrentHash+".fastresume", torrent.Name)
-			}
-
-			// write new torrent file to destination path
-			newTorrentFile, err := os.Create(outFile)
-			if err != nil {
-				return errors.Wrapf(err, "could not create new torrent file: %s", outFile)
-			}
-			defer newTorrentFile.Close()
-
-			if err := torrentInfo.Write(newTorrentFile); err != nil {
-				return errors.Wrapf(err, "could not write torrent info into file %s", outFile)
-			}
-
-			// all good lets return for this file
-			exportTorrentCount++
-			log.Printf("[%d/%d] exported: %s    %s\n", exportTorrentCount, len(hashes), fileName, torrent.Name)
-
-			return nil
-		}
-
-		// only do this if !needTrackerFix
-		if err := fsutil.CopyFile(dirPath, outFile); err != nil {
-			return errors.Wrapf(err, "could not copy file: %s to %s", dirPath, outFile)
-		}
-
-		exportTorrentCount++
-		log.Printf("[%d/%d] exported: %s    %s\n", exportTorrentCount, len(hashes), fileName, torrent.Name)
-
-		// process if fastresume has not already been copied
-		_, ok = processedFastResumeHashes[torrentHash]
-		if !ok {
-			fastResumeFilePath := filepath.Join(exportDir, torrentHash+".fastresume")
-
-			if err := fsutil.CopyFile(dirPath, fastResumeFilePath); err != nil {
-				return errors.Wrapf(err, "could not copy file: %s to %s", dirPath, fastResumeFilePath)
-			}
-
-			exportFastresumeCount++
-			log.Printf("[%d/%d] exported: %s %s\n", exportFastresumeCount, len(hashes), torrentHash+".fastresume", torrent.Name)
+			// remove any half-written output for this torrent so the export dir
+			// never ends up with a partial or mismatched .torrent/.fastresume pair
+			_ = os.Remove(filepath.Join(exportDir, fileName))
+			_ = os.Remove(filepath.Join(exportDir, torrentHash+".fastresume"))
 		}
 
 		return nil
@@ -459,6 +493,16 @@ func processExport(sourceDir, exportDir string, hashes map[string]qbittorrent.To
 	}
 
 	log.Printf("Exported (%d) files in total: fastresume (%d) torrents (%d)\n", exportFastresumeCount+exportTorrentCount, exportFastresumeCount, exportTorrentCount)
+
+	if failedCount > 0 {
+		log.Printf("Skipped (%d) torrents due to errors, see the messages above\n", failedCount)
+	}
+
+	// if every matched torrent failed to export, surface it as an error instead of
+	// reporting success - otherwise a fully broken run would still exit 0
+	if exportTorrentCount == 0 && failedCount > 0 {
+		return errors.Errorf("failed to export any torrents (%d skipped due to errors)", failedCount)
+	}
 
 	return nil
 }

--- a/cmd/torrent_export_test.go
+++ b/cmd/torrent_export_test.go
@@ -1,8 +1,15 @@
 package cmd
 
 import (
-	"github.com/autobrr/go-qbittorrent"
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/anacrolix/torrent/metainfo"
+	"github.com/autobrr/go-qbittorrent"
+	"github.com/zeebo/bencode"
 )
 
 func Test_export_processHashes(t *testing.T) {
@@ -37,5 +44,155 @@ func Test_export_processHashes(t *testing.T) {
 				t.Errorf("processExport() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// minimal single-file torrent with no announce, which forces processExport down
+// the path that reads the matching .fastresume to recover the trackers.
+const torrentNoAnnounce = "d4:infod6:lengthi1e4:name1:a12:piece lengthi16384e6:pieces0:ee"
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("could not write %s: %v", path, err)
+	}
+}
+
+// Test_processExport_continuesOnBadFastresume verifies that a single problematic
+// fastresume file does not abort the whole export: the bad file is skipped and the
+// remaining torrents are still exported (issue #135).
+func Test_processExport_continuesOnBadFastresume(t *testing.T) {
+	sourceDir := t.TempDir()
+	exportDir := t.TempDir()
+
+	const badHash = "1111111111111111111111111111111111111111"  // sorts first
+	const goodHash = "2222222222222222222222222222222222222222" // sorts after the bad one
+
+	// bad pair: valid torrent but an unparseable fastresume
+	writeFile(t, filepath.Join(sourceDir, badHash+".torrent"), []byte(torrentNoAnnounce))
+	writeFile(t, filepath.Join(sourceDir, badHash+".fastresume"), []byte("this is not bencode"))
+
+	// good pair: valid torrent + fastresume that stores trackers as a flat list
+	goodFastresume, err := bencode.EncodeBytes(map[string]interface{}{
+		"save_path": "/downloads",
+		"trackers":  []string{"https://tracker/announce"},
+	})
+	if err != nil {
+		t.Fatalf("could not encode good fastresume: %v", err)
+	}
+	writeFile(t, filepath.Join(sourceDir, goodHash+".torrent"), []byte(torrentNoAnnounce))
+	writeFile(t, filepath.Join(sourceDir, goodHash+".fastresume"), goodFastresume)
+
+	hashes := map[string]qbittorrent.Torrent{
+		badHash:  {},
+		goodHash: {},
+	}
+
+	if err := processExport(sourceDir, exportDir, hashes, false, false); err != nil {
+		t.Fatalf("processExport() returned error, want nil: %v", err)
+	}
+
+	// the good torrent (and its fastresume) must have been exported
+	mustExist(t, filepath.Join(exportDir, goodHash+".torrent"))
+	mustExist(t, filepath.Join(exportDir, goodHash+".fastresume"))
+
+	// the bad torrent must have been skipped, not exported
+	mustNotExist(t, filepath.Join(exportDir, badHash+".torrent"))
+	mustNotExist(t, filepath.Join(exportDir, badHash+".fastresume"))
+
+	// the flat-list trackers from the fastresume must have been recovered into the
+	// exported .torrent (announce + announce-list), proving the end-to-end fix
+	mi, err := metainfo.LoadFromFile(filepath.Join(exportDir, goodHash+".torrent"))
+	if err != nil {
+		t.Fatalf("could not load exported torrent: %v", err)
+	}
+	if mi.Announce != "https://tracker/announce" {
+		t.Errorf("exported torrent Announce = %q, want %q", mi.Announce, "https://tracker/announce")
+	}
+	wantAnnounceList := metainfo.AnnounceList{{"https://tracker/announce"}}
+	if !reflect.DeepEqual(mi.AnnounceList, wantAnnounceList) {
+		t.Errorf("exported torrent AnnounceList = %#v, want %#v", mi.AnnounceList, wantAnnounceList)
+	}
+}
+
+// minimal single-file torrent that already carries an announce URL. Torrents like
+// this (pre v4.5.x qBittorrent) keep the trackers in the .torrent, so processExport
+// takes the plain copy path instead of rebuilding from the .fastresume.
+const torrentWithAnnounce = "d8:announce17:http://t/announce4:infod6:lengthi1e4:name1:a12:piece lengthi16384e6:pieces0:ee"
+
+// Test_processExport_copyBranchExportsRealFastresume guards the copy path: the
+// exported .fastresume must be a copy of the SOURCE .fastresume, not of the
+// .torrent file (the latter was a real bug). The copy path only runs from the
+// second announce-carrying torrent onwards, so we export two of them.
+func Test_processExport_copyBranchExportsRealFastresume(t *testing.T) {
+	sourceDir := t.TempDir()
+	exportDir := t.TempDir()
+
+	const firstHash = "1111111111111111111111111111111111111111"
+	const secondHash = "2222222222222222222222222222222222222222"
+
+	torrentBytes := []byte(torrentWithAnnounce)
+	secondFastresume := []byte("FASTRESUME-CONTENT-FOR-SECOND-TORRENT")
+
+	writeFile(t, filepath.Join(sourceDir, firstHash+".torrent"), torrentBytes)
+	writeFile(t, filepath.Join(sourceDir, firstHash+".fastresume"), []byte("FASTRESUME-CONTENT-FOR-FIRST-TORRENT"))
+	writeFile(t, filepath.Join(sourceDir, secondHash+".torrent"), torrentBytes)
+	writeFile(t, filepath.Join(sourceDir, secondHash+".fastresume"), secondFastresume)
+
+	hashes := map[string]qbittorrent.Torrent{
+		firstHash:  {},
+		secondHash: {},
+	}
+
+	if err := processExport(sourceDir, exportDir, hashes, false, false); err != nil {
+		t.Fatalf("processExport() returned error, want nil: %v", err)
+	}
+
+	// the second torrent goes through the copy path; its exported .fastresume must
+	// byte-equal the source .fastresume (and must NOT be the .torrent content)
+	got, err := os.ReadFile(filepath.Join(exportDir, secondHash+".fastresume"))
+	if err != nil {
+		t.Fatalf("could not read exported fastresume: %v", err)
+	}
+	if !bytes.Equal(got, secondFastresume) {
+		t.Errorf("exported fastresume = %q, want source fastresume %q", got, secondFastresume)
+	}
+	if bytes.Equal(got, torrentBytes) {
+		t.Errorf("exported fastresume wrongly contains the .torrent bytes")
+	}
+}
+
+// Test_processExport_allFailReturnsError verifies that when every matched torrent
+// fails to export, processExport surfaces an error instead of reporting success.
+func Test_processExport_allFailReturnsError(t *testing.T) {
+	sourceDir := t.TempDir()
+	exportDir := t.TempDir()
+
+	const hash = "1111111111111111111111111111111111111111"
+	writeFile(t, filepath.Join(sourceDir, hash+".torrent"), []byte(torrentNoAnnounce))
+	writeFile(t, filepath.Join(sourceDir, hash+".fastresume"), []byte("this is not bencode"))
+
+	hashes := map[string]qbittorrent.Torrent{hash: {}}
+
+	if err := processExport(sourceDir, exportDir, hashes, false, false); err == nil {
+		t.Fatal("processExport() returned nil, want error when all torrents fail")
+	}
+
+	// nothing should have been written to the export dir
+	mustNotExist(t, filepath.Join(exportDir, hash+".torrent"))
+	mustNotExist(t, filepath.Join(exportDir, hash+".fastresume"))
+}
+
+func mustExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file to exist: %s (%v)", path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected file to not exist: %s (err=%v)", path, err)
 	}
 }

--- a/pkg/qbittorrent/fastresume.go
+++ b/pkg/qbittorrent/fastresume.go
@@ -3,6 +3,7 @@ package qbittorrent
 import (
 	"bufio"
 	"crypto/sha1"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -68,7 +69,7 @@ type Fastresume struct {
 	SuperSeeding              int64                  `bencode:"super_seeding"`
 	TotalDownloaded           int64                  `bencode:"total_downloaded"`
 	TotalUploaded             int64                  `bencode:"total_uploaded"`
-	Trackers                  [][]string             `bencode:"trackers"`
+	Trackers                  TrackerTiers           `bencode:"trackers"`
 	UploadMode                int64                  `bencode:"upload_mode"`
 	UploadRateLimit           int64                  `bencode:"upload_rate_limit"`
 	UrlList                   []string               `bencode:"url-list"`
@@ -85,6 +86,52 @@ type Fastresume struct {
 	NumPieces                 int64                  `bencode:"-"`
 	PieceLength               int64                  `bencode:"-"`
 	MappedFiles               []string               `bencode:"mapped_files,omitempty"`
+}
+
+// TrackerTiers represents the libtorrent fastresume "trackers" field.
+//
+// qBittorrent/libtorrent normally writes a list of tiers, where each tier is a
+// list of tracker URLs ([][]string). Some clients and older versions instead
+// write a flat list of URLs ([]string) or even a single (whitespace separated)
+// string. The default decoder fails on those variants with
+// "Cannot store string into []string", which used to abort the whole
+// `torrent export` command. UnmarshalBencode normalizes all of these shapes into
+// the standard [][]string form so the file can still be processed.
+type TrackerTiers [][]string
+
+// UnmarshalBencode implements bencode.Unmarshaler.
+func (t *TrackerTiers) UnmarshalBencode(b []byte) error {
+	// Standard format: a list of tiers ([][]string).
+	var tiers [][]string
+	if err := bencode.DecodeBytes(b, &tiers); err == nil {
+		*t = tiers
+		return nil
+	}
+
+	// Flat format: a single list of URLs ([]string). Wrap each URL in its own tier.
+	var urls []string
+	if err := bencode.DecodeBytes(b, &urls); err == nil {
+		tiers = make([][]string, 0, len(urls))
+		for _, url := range urls {
+			tiers = append(tiers, []string{url})
+		}
+		*t = tiers
+		return nil
+	}
+
+	// Single string, possibly whitespace separated.
+	var single string
+	if err := bencode.DecodeBytes(b, &single); err == nil {
+		fields := strings.Fields(single)
+		tiers = make([][]string, 0, len(fields))
+		for _, url := range fields {
+			tiers = append(tiers, []string{url})
+		}
+		*t = tiers
+		return nil
+	}
+
+	return fmt.Errorf("could not decode trackers field: unsupported format %q", string(b))
 }
 
 // Encode qBittorrent fastresume file

--- a/pkg/qbittorrent/fastresume_test.go
+++ b/pkg/qbittorrent/fastresume_test.go
@@ -1,0 +1,102 @@
+package qbittorrent
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zeebo/bencode"
+)
+
+func TestTrackerTiers_UnmarshalBencode(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   interface{}
+		want    [][]string
+		wantErr bool
+	}{
+		{
+			name:  "nested tiers (standard qBittorrent format)",
+			input: [][]string{{"https://a/announce"}, {"udp://b:1337"}},
+			want:  [][]string{{"https://a/announce"}, {"udp://b:1337"}},
+		},
+		{
+			name:  "nested tier with multiple urls",
+			input: [][]string{{"https://a/announce", "https://a-backup/announce"}},
+			want:  [][]string{{"https://a/announce", "https://a-backup/announce"}},
+		},
+		{
+			// this is the shape that produced "Cannot store string into []string"
+			name:  "flat list of urls",
+			input: []string{"https://a/announce", "udp://b:1337"},
+			want:  [][]string{{"https://a/announce"}, {"udp://b:1337"}},
+		},
+		{
+			name:  "single url string",
+			input: "https://a/announce",
+			want:  [][]string{{"https://a/announce"}},
+		},
+		{
+			name:  "single whitespace separated string",
+			input: "https://a/announce udp://b:1337",
+			want:  [][]string{{"https://a/announce"}, {"udp://b:1337"}},
+		},
+		{
+			name:  "empty list",
+			input: []string{},
+			want:  nil,
+		},
+		{
+			name:    "unsupported type",
+			input:   int64(5),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := bencode.EncodeBytes(tt.input)
+			if err != nil {
+				t.Fatalf("could not encode test input: %v", err)
+			}
+
+			var got TrackerTiers
+			err = bencode.DecodeBytes(encoded, &got)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalBencode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual([][]string(got), tt.want) {
+				t.Errorf("UnmarshalBencode() = %#v, want %#v", [][]string(got), tt.want)
+			}
+		})
+	}
+}
+
+// TestFastresume_DecodeFlatTrackers ensures a full fastresume that stores the
+// trackers field as a flat list of strings can still be decoded. This is the
+// exact failure reported in issue #135.
+func TestFastresume_DecodeFlatTrackers(t *testing.T) {
+	raw := map[string]interface{}{
+		"save_path": "/downloads",
+		"trackers":  []string{"https://a/announce", "udp://b:1337"},
+	}
+
+	encoded, err := bencode.EncodeBytes(raw)
+	if err != nil {
+		t.Fatalf("could not encode fastresume: %v", err)
+	}
+
+	var fr Fastresume
+	if err := bencode.DecodeBytes(encoded, &fr); err != nil {
+		t.Fatalf("could not decode fastresume with flat trackers: %v", err)
+	}
+
+	want := [][]string{{"https://a/announce"}, {"udp://b:1337"}}
+	if !reflect.DeepEqual([][]string(fr.Trackers), want) {
+		t.Errorf("Trackers = %#v, want %#v", [][]string(fr.Trackers), want)
+	}
+}


### PR DESCRIPTION
Improve error handling of torrent export so it doesn't fail on the first error.

This also fixes the core issue from #135 with the different tracker list format.

Fixes #135 