### PR TITLE
fix(torrent): resume and pause with args

### DIFF
--- a/cmd/torrent_pause.go
+++ b/cmd/torrent_pause.go
@@ -15,26 +15,38 @@ import (
 func RunTorrentPause() *cobra.Command {
 	var (
 		pauseAll bool
-		names    bool
 		hashes   []string
 	)
 
 	var command = &cobra.Command{
 		Use:   "pause",
 		Short: "Pause specified torrent(s)",
-		Long:  `Pauses torrents indicated by hash, name or a prefix of either. Whitespace indicates next prefix unless argument is surrounded by quotes`,
+		Long:  `Pause the torrent(s) indicated by the supplied hash(es), or pause every torrent with --all.`,
+		Example: `  qbt torrent pause --all
+  qbt torrent pause HASH1 HASH2
+  qbt torrent pause --hashes HASH1,HASH2`,
 	}
 
 	command.Flags().BoolVar(&pauseAll, "all", false, "Pauses all torrents")
 	command.Flags().StringSliceVar(&hashes, "hashes", []string{}, "Add hashes as comma separated list")
-	command.Flags().BoolVar(&names, "names", false, "Provided arguments will be read as torrent names")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		if len(hashes) > 0 {
+		// Treat positional arguments as hashes too, so `qbt torrent pause HASH` works
+		// alongside the --hashes flag.
+		hashes = append(hashes, args...)
+
+		if pauseAll {
+			hashes = []string{"all"}
+		} else {
+			if len(hashes) == 0 {
+				return errors.New("no torrents specified: provide hash(es) as arguments or with --hashes, or use --all")
+			}
+
 			if err := utils.ValidateHash(hashes); err != nil {
 				return errors.Wrap(err, "invalid hashes supplied")
 			}
 		}
+
 		config.InitConfig()
 
 		qbtSettings := qbittorrent.Config{
@@ -54,19 +66,9 @@ func RunTorrentPause() *cobra.Command {
 			return errors.Wrap(err, "could not login to qbit")
 		}
 
-		if pauseAll {
-			hashes = []string{"all"}
-		}
-
-		if len(hashes) == 0 {
-			log.Printf("No torrents found to pause with provided hashes. Use --all to pause all torrents.")
-			return nil
-		}
-
-		err := batchRequests(hashes, func(start, end int) error {
+		if err := batchRequests(hashes, func(start, end int) error {
 			return qb.PauseCtx(ctx, hashes[start:end])
-		})
-		if err != nil {
+		}); err != nil {
 			return errors.Wrap(err, "could not pause torrents")
 		}
 

--- a/cmd/torrent_pause_test.go
+++ b/cmd/torrent_pause_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestRunTorrentPause_requiresTarget mirrors the resume guard (issue #132):
+// `qbt torrent pause` with no target must fail loudly instead of silently
+// no-opping. Both error paths return before any network call, so the command
+// can be exercised without a live qBittorrent.
+func TestRunTorrentPause_requiresTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no target returns error instead of no-op success",
+			args:    []string{},
+			wantErr: "no torrents specified",
+		},
+		{
+			name:    "invalid positional hash is rejected",
+			args:    []string{"not-a-valid-hash"},
+			wantErr: "invalid hashes supplied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command := RunTorrentPause()
+			command.SetArgs(tt.args)
+			command.SetOut(io.Discard)
+			command.SetErr(io.Discard)
+
+			err := command.Execute()
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}

--- a/cmd/torrent_resume.go
+++ b/cmd/torrent_resume.go
@@ -22,14 +22,27 @@ func RunTorrentResume() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "resume",
 		Short: "Resume specified torrent(s)",
-		Long:  `Resumes torrents indicated by hash, name or a prefix of either. Whitespace indicates next prefix unless argument is surrounded by quotes`,
+		Long:  `Resume the torrent(s) indicated by the supplied hash(es), or resume every torrent with --all.`,
+		Example: `  qbt torrent resume --all
+  qbt torrent resume HASH1 HASH2
+  qbt torrent resume --hashes HASH1,HASH2`,
 	}
 
 	command.Flags().BoolVar(&resumeAll, "all", false, "resumes all torrents")
 	command.Flags().StringSliceVar(&hashes, "hashes", []string{}, "Add hashes as comma separated list")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		if len(hashes) > 0 {
+		// Treat positional arguments as hashes too, so `qbt torrent resume HASH` works
+		// alongside the --hashes flag.
+		hashes = append(hashes, args...)
+
+		if resumeAll {
+			hashes = []string{"all"}
+		} else {
+			if len(hashes) == 0 {
+				return errors.New("no torrents specified: provide hash(es) as arguments or with --hashes, or use --all")
+			}
+
 			if err := utils.ValidateHash(hashes); err != nil {
 				return errors.Wrap(err, "invalid hashes supplied")
 			}
@@ -54,14 +67,9 @@ func RunTorrentResume() *cobra.Command {
 			return errors.Wrap(err, "could not login to qbit")
 		}
 
-		if resumeAll {
-			hashes = []string{"all"}
-		}
-
-		err := batchRequests(hashes, func(start, end int) error {
+		if err := batchRequests(hashes, func(start, end int) error {
 			return qb.ResumeCtx(ctx, hashes[start:end])
-		})
-		if err != nil {
+		}); err != nil {
 			return errors.Wrap(err, "could not resume torrents")
 		}
 

--- a/cmd/torrent_resume_test.go
+++ b/cmd/torrent_resume_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestRunTorrentResume_requiresTarget guards against the false-positive reported
+// in issue #132: `qbt torrent resume` with no target must fail loudly instead of
+// printing "torrent(s) successfully resumed". Both error paths return before any
+// network call, so the command can be exercised without a live qBittorrent.
+func TestRunTorrentResume_requiresTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no target returns error instead of false-positive success",
+			args:    []string{},
+			wantErr: "no torrents specified",
+		},
+		{
+			name:    "invalid positional hash is rejected",
+			args:    []string{"not-a-valid-hash"},
+			wantErr: "invalid hashes supplied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command := RunTorrentResume()
+			command.SetArgs(tt.args)
+			command.SetOut(io.Discard)
+			command.SetErr(io.Discard)
+
+			err := command.Execute()
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix args/hashes handling for pause and resume commands.

Fixes #132 