### PR TITLE
chore: add v2 suffix to module

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/bencode.go
+++ b/cmd/bencode.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/qbittorrent"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/category.go
+++ b/cmd/category.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/qbt/main.go
+++ b/cmd/qbt/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/ludviglundgren/qbittorrent-cli/cmd"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/cmd"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"log"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/torrent_add.go
+++ b/cmd/torrent_add.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/autobrr/go-qbittorrent"

--- a/cmd/torrent_category.go
+++ b/cmd/torrent_category.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/utils"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/torrent_compare.go
+++ b/cmd/torrent_compare.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/dustin/go-humanize"

--- a/cmd/torrent_export.go
+++ b/cmd/torrent_export.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
-	fsutil "github.com/ludviglundgren/qbittorrent-cli/internal/fs"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/archive"
-	qbit "github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
+	fsutil "github.com/ludviglundgren/qbittorrent-cli/v2/internal/fs"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/archive"
+	qbit "github.com/ludviglundgren/qbittorrent-cli/v2/pkg/qbittorrent"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/utils"
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/autobrr/go-qbittorrent"

--- a/cmd/torrent_import.go
+++ b/cmd/torrent_import.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/importer"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/importer"
 
 	"github.com/mholt/archives"
 	"github.com/mitchellh/go-homedir"

--- a/cmd/torrent_list.go
+++ b/cmd/torrent_list.go
@@ -9,8 +9,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/utils"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/autobrr/go-qbittorrent/errors"

--- a/cmd/torrent_pause.go
+++ b/cmd/torrent_pause.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"log"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/utils"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/torrent_reannounce.go
+++ b/cmd/torrent_reannounce.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/torrent_recheck.go
+++ b/cmd/torrent_recheck.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"log"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/utils"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/torrent_remove.go
+++ b/cmd/torrent_remove.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"log"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/utils"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/torrent_resume.go
+++ b/cmd/torrent_resume.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/utils"
 	"github.com/pkg/errors"
 
 	"github.com/autobrr/go-qbittorrent"

--- a/cmd/torrent_share_limit.go
+++ b/cmd/torrent_share_limit.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/utils"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/utils"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/torrent_tag.go
+++ b/cmd/torrent_tag.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/dustin/go-humanize"

--- a/cmd/torrent_tracker.go
+++ b/cmd/torrent_tracker.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/pkg/errors"

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/config"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/config"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/dustin/go-humanize"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ludviglundgren/qbittorrent-cli
+module github.com/ludviglundgren/qbittorrent-cli/v2
 
 go 1.25.0
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/domain"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/domain"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"

--- a/internal/importer/deluge.go
+++ b/internal/importer/deluge.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/fs"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/fs"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/qbittorrent"
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/pkg/errors"

--- a/internal/importer/rtorrent.go
+++ b/internal/importer/rtorrent.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ludviglundgren/qbittorrent-cli/internal/fs"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/qbittorrent"
-	"github.com/ludviglundgren/qbittorrent-cli/pkg/torrent"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/internal/fs"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/qbittorrent"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/pkg/torrent"
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/pkg/errors"

--- a/tools/gen-docs/main.go
+++ b/tools/gen-docs/main.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ludviglundgren/qbittorrent-cli/cmd"
+	"github.com/ludviglundgren/qbittorrent-cli/v2/cmd"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"


### PR DESCRIPTION
Add v2 suffix to module name to fix `go install`.

Fixes #170 